### PR TITLE
Fix LSP lookup for @-prefixed QTN identifiers

### DIFF
--- a/language-server/src/__tests__/word-at-position-handlers.test.ts
+++ b/language-server/src/__tests__/word-at-position-handlers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { MarkupKind, type HoverParams, type DefinitionParams } from 'vscode-languageserver';
+import { ProjectModel } from '../project-model.js';
+import { handleDefinition } from '../definition.js';
+import { handleHover } from '../hover.js';
+
+function createDocumentStore(uri: string, text: string) {
+  const doc = TextDocument.create(uri, 'qtn', 1, text);
+  return {
+    doc,
+    documents: {
+      get(targetUri: string) {
+        return targetUri === uri ? doc : undefined;
+      },
+    },
+  };
+}
+
+describe('Word extraction in LSP handlers', () => {
+  it('resolves definition for identifiers prefixed with @', () => {
+    const uri = 'file:///test-at-definition.qtn';
+    const text = `
+struct @Player {
+  int hp;
+}
+
+component Game {
+  @Player actor;
+}
+`;
+
+    const { doc, documents } = createDocumentStore(uri, text);
+    const projectModel = new ProjectModel();
+    projectModel.updateDocument(uri, text);
+
+    const usageOffset = text.indexOf('@Player actor') + 2;
+    const usagePos = doc.positionAt(usageOffset);
+
+    const params: DefinitionParams = {
+      textDocument: { uri },
+      position: usagePos,
+    };
+
+    const definition = handleDefinition(params, projectModel, documents as never);
+    expect(definition).not.toBeNull();
+    expect(definition?.uri).toBe(uri);
+    expect(definition?.range.start.line).toBe(1);
+  });
+
+  it('shows hover for user-defined identifiers prefixed with @', () => {
+    const uri = 'file:///test-at-hover.qtn';
+    const text = `
+struct @Player {
+  int hp;
+}
+
+component Game {
+  @Player actor;
+}
+`;
+
+    const { doc, documents } = createDocumentStore(uri, text);
+    const projectModel = new ProjectModel();
+    projectModel.updateDocument(uri, text);
+
+    const usageOffset = text.indexOf('@Player actor') + 2;
+    const usagePos = doc.positionAt(usageOffset);
+
+    const params: HoverParams = {
+      textDocument: { uri },
+      position: usagePos,
+    };
+
+    const hover = handleHover(params, projectModel, documents as never);
+    expect(hover).not.toBeNull();
+    expect(hover?.contents).toMatchObject({
+      kind: MarkupKind.Markdown,
+    });
+
+    const value = typeof hover?.contents === 'string'
+      ? hover.contents
+      : Array.isArray(hover?.contents)
+        ? hover.contents.map(c => ('value' in c ? c.value : '')).join('\n')
+        : hover?.contents.value;
+
+    expect(value).toContain('Declared in');
+  });
+});

--- a/language-server/src/definition.ts
+++ b/language-server/src/definition.ts
@@ -39,7 +39,7 @@ export function handleDefinition(
 
 /**
  * Get the word at a given position in the document.
- * A word consists of alphanumeric characters and underscores [a-zA-Z0-9_].
+ * A word consists of alphanumeric characters, underscores, and @ [a-zA-Z0-9_@].
  *
  * @param document - The text document
  * @param position - The cursor position
@@ -72,11 +72,11 @@ function getWordAtPosition(document: TextDocument, position: Position): string |
 
 /**
  * Check if a character is a valid word character.
- * Word characters: [a-zA-Z0-9_]
+ * Word characters: [a-zA-Z0-9_@]
  *
  * @param ch - Character to check
  * @returns true if ch is a word character
  */
 function isWordChar(ch: string): boolean {
-  return /[a-zA-Z0-9_]/.test(ch);
+  return /[a-zA-Z0-9_@]/.test(ch);
 }

--- a/language-server/src/hover.ts
+++ b/language-server/src/hover.ts
@@ -209,7 +209,7 @@ function createUserDefinedHover(info: import('./symbol-table.js').SymbolInfo): H
 
 /**
  * Get the word at a given position in the document.
- * A word consists of alphanumeric characters and underscores [a-zA-Z0-9_].
+ * A word consists of alphanumeric characters, underscores, and @ [a-zA-Z0-9_@].
  * Also handles '#' prefix for preprocessor keywords (#pragma, #define).
  *
  * @param document - The text document
@@ -248,11 +248,11 @@ function getWordAtPosition(document: TextDocument, position: Position): string |
 
 /**
  * Check if a character is a valid word character.
- * Word characters: [a-zA-Z0-9_]
+ * Word characters: [a-zA-Z0-9_@]
  *
  * @param ch - Character to check
  * @returns true if ch is a word character
  */
 function isWordChar(ch: string): boolean {
-  return /[a-zA-Z0-9_]/.test(ch);
+  return /[a-zA-Z0-9_@]/.test(ch);
 }


### PR DESCRIPTION
### Motivation
- Definition and hover handlers did not treat `@`-prefixed (escaped) identifiers as part of the word, causing go-to-definition and hover to fail for names like `@Player`.
- The change aims to make symbol extraction consistent with lexer/AST rules that allow `@` in identifiers so LSP features work for escaped names.

### Description
- Treat `@` as a valid identifier character by extending the word-char check (`/[a-zA-Z0-9_@]/`) in both `definition.ts` and `hover.ts` (`getWordAtPosition` / `isWordChar`).
- Ensure `getWordAtPosition` behavior is identical between definition and hover handlers to avoid inconsistent resolution.
- Add a regression test `src/__tests__/word-at-position-handlers.test.ts` that verifies both go-to-definition and hover work for `@`-prefixed user symbols.

### Testing
- Ran unit tests with `cd language-server && npm test -- --run` and all tests passed (25/25).
- Built the language server with `cd language-server && npm run build` which completed successfully.
- Noted that running `cd vscode-extension && npm run test:snap` still reports unrelated existing snapshot differences for `tests/snap/sample.qtn` (token scope differences) and `./build.sh all` failed due to a missing Docker environment, both of which are pre-existing and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb73c4b4883249b618ea66898301f)