### PR TITLE
perf: make symbol-table updates incremental per document

### DIFF
--- a/language-server/src/__tests__/incremental-symbol-table.test.ts
+++ b/language-server/src/__tests__/incremental-symbol-table.test.ts
@@ -1,0 +1,107 @@
+// Tests for incremental symbol-table updates.
+//
+// Updating one document must not drop symbols contributed by other documents,
+// builtins must persist across updates without being rebuilt from scratch, and
+// removing a document must drop only that document's symbols.
+
+import { describe, it, expect } from 'vitest';
+import { ProjectModel } from '../project-model.js';
+import { SymbolTable } from '../symbol-table.js';
+import { parse } from '../parser.js';
+
+describe('Incremental symbol table', () => {
+  it('updating one document keeps another document\'s symbols', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }');
+    pm.updateDocument('test://b.qtn', 'component Beta { FP B; }');
+
+    expect(pm.findDefinition('Alpha')).not.toBeNull();
+    expect(pm.findDefinition('Beta')).not.toBeNull();
+
+    // Re-edit only document A; B's symbol must survive.
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; Int32 Extra; }');
+
+    expect(pm.findDefinition('Alpha')).not.toBeNull();
+    expect(pm.findDefinition('Beta')).not.toBeNull();
+  });
+
+  it('builtins persist across document updates', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }');
+
+    const fpBefore = pm.getSymbolTable().lookup('FP');
+    expect(fpBefore?.source).toBe('builtin');
+
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; FP B; }');
+
+    const fpAfter = pm.getSymbolTable().lookup('FP');
+    expect(fpAfter?.source).toBe('builtin');
+  });
+
+  it('removeDocument drops only that document\'s symbols', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }');
+    pm.updateDocument('test://b.qtn', 'component Beta { FP B; }');
+
+    pm.removeDocument('test://a.qtn');
+
+    expect(pm.findDefinition('Alpha')).toBeNull();
+    expect(pm.findDefinition('Beta')).not.toBeNull();
+    // Builtins remain available after a removal.
+    expect(pm.getSymbolTable().lookup('FP')?.source).toBe('builtin');
+  });
+
+  it('removing a document that shadowed a builtin restores the builtin', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://shadow.qtn', 'struct FP { Int32 X; }');
+
+    expect(pm.getSymbolTable().lookup('FP')?.source).toBe('user');
+
+    pm.removeDocument('test://shadow.qtn');
+
+    expect(pm.getSymbolTable().lookup('FP')?.source).toBe('builtin');
+  });
+
+  it('keeps a later document\'s winner when an earlier document is re-edited', () => {
+    const pm = new ProjectModel();
+    // Both documents define Shared; the later-inserted b.qtn wins, matching the
+    // old full-rebuild insertion-order semantics.
+    pm.updateDocument('test://a.qtn', 'component Shared { FP A; }');
+    pm.updateDocument('test://b.qtn', 'struct Shared { Int32 B; }');
+
+    const winnerBefore = pm.getSymbolTable().lookup('Shared');
+    expect(winnerBefore?.location.uri).toBe('test://b.qtn');
+
+    // Re-edit a.qtn (still defines Shared, grows by a field). b.qtn must still win.
+    pm.updateDocument('test://a.qtn', 'component Shared { FP A; FP A2; }');
+
+    const winnerAfter = pm.getSymbolTable().lookup('Shared');
+    expect(winnerAfter?.location.uri).toBe('test://b.qtn');
+  });
+
+  it('drops a name when a re-edit removes its definition', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }\ncomponent Gamma { FP G; }');
+    expect(pm.findDefinition('Gamma')).not.toBeNull();
+
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }');
+    expect(pm.findDefinition('Alpha')).not.toBeNull();
+    expect(pm.findDefinition('Gamma')).toBeNull();
+  });
+
+  it('SymbolTable.removeDocument removes a single document\'s contribution', () => {
+    const table = new SymbolTable();
+    table.mergeBuiltins();
+    table.addFromDocument(parse('component Alpha { FP A; }', 'test://a.qtn'));
+    table.addFromDocument(parse('#define FOO 1', 'test://b.qtn'));
+
+    expect(table.lookup('Alpha')).toBeDefined();
+    expect(table.lookup('FOO')).toBeDefined();
+
+    table.removeDocument('test://b.qtn');
+
+    expect(table.lookup('Alpha')).toBeDefined();
+    expect(table.lookup('FOO')).toBeUndefined();
+    expect(table.lookup('FP')?.source).toBe('builtin');
+  });
+});

--- a/language-server/src/project-model.ts
+++ b/language-server/src/project-model.ts
@@ -12,24 +12,24 @@ import { SymbolTable, SymbolInfo } from './symbol-table.js';
  * - A map of URI -> parsed QtnDocument
  * - A unified SymbolTable aggregating symbols from all documents
  *
- * When documents change, the symbol table is rebuilt from scratch to ensure consistency.
+ * Symbol-table updates are incremental: a changed document only re-indexes its
+ * own symbols, and builtins are computed once and reused. Removing a document
+ * drops only that document's symbols.
  */
 export class ProjectModel {
   private documents: Map<string, QtnDocument>;
   private symbolTable: SymbolTable;
-  private dirty: boolean;
 
   constructor() {
     this.documents = new Map();
     this.symbolTable = new SymbolTable();
-    this.dirty = false;
     // Pre-populate with built-in types
     this.symbolTable.mergeBuiltins();
   }
 
   /**
-   * Update a document: re-parse the text and mark symbol table as dirty.
-   * The symbol table will be lazily rebuilt on next access.
+   * Update a document: re-parse the text and re-index only this document's
+   * symbols into the shared symbol table.
    * @param uri - Document URI
    * @param text - Full document text
    */
@@ -54,19 +54,17 @@ export class ProjectModel {
     // Store in documents map
     this.documents.set(uri, doc);
 
-    // Mark symbol table as dirty for lazy rebuild
-    this.dirty = true;
+    // Re-index only this document; other documents and builtins are untouched.
+    this.symbolTable.addFromDocument(doc);
   }
 
   /**
-   * Remove a document from the project model.
+   * Remove a document from the project model along with its symbols.
    * @param uri - Document URI to remove
    */
   removeDocument(uri: string): void {
     this.documents.delete(uri);
-
-    // Mark symbol table as dirty for lazy rebuild
-    this.dirty = true;
+    this.symbolTable.removeDocument(uri);
   }
 
   /**
@@ -88,12 +86,9 @@ export class ProjectModel {
 
   /**
    * Get all symbols from the symbol table.
-   * Rebuilds the symbol table if it's marked as dirty.
    * @returns Array of all SymbolInfo objects
    */
   getAllSymbols(): SymbolInfo[] {
-    this.ensureSymbolTableFresh();
-
     const symbols: SymbolInfo[] = [];
 
     // Collect all type symbols
@@ -111,13 +106,10 @@ export class ProjectModel {
 
   /**
    * Find the definition location of a symbol by name.
-   * Rebuilds the symbol table if it's marked as dirty.
    * @param name - Symbol name to look up
    * @returns Location if found and user-defined, null otherwise
    */
   findDefinition(name: string): Location | null {
-    this.ensureSymbolTableFresh();
-
     const symbol = this.symbolTable.lookup(name);
 
     // Only return user-defined symbols (not builtins or imports)
@@ -130,39 +122,9 @@ export class ProjectModel {
 
   /**
    * Get the symbol table for direct access by handlers.
-   * Rebuilds the symbol table if it's marked as dirty.
    * @returns The SymbolTable instance
    */
   getSymbolTable(): SymbolTable {
-    this.ensureSymbolTableFresh();
     return this.symbolTable;
-  }
-
-  /**
-   * Ensure the symbol table is fresh, rebuilding if necessary.
-   * This is called by all methods that access the symbol table.
-   */
-  private ensureSymbolTableFresh(): void {
-    if (this.dirty) {
-      this.rebuildSymbolTable();
-      this.dirty = false;
-    }
-  }
-
-  /**
-   * Rebuild the symbol table from all documents.
-   * This creates a fresh symbol table, merges builtins, then adds symbols from each document.
-   */
-  private rebuildSymbolTable(): void {
-    // Create new symbol table
-    this.symbolTable = new SymbolTable();
-
-    // Pre-populate with built-ins
-    this.symbolTable.mergeBuiltins();
-
-    // Add symbols from each document
-    for (const doc of this.documents.values()) {
-      this.symbolTable.addFromDocument(doc);
-    }
   }
 }

--- a/language-server/src/symbol-table.ts
+++ b/language-server/src/symbol-table.ts
@@ -93,28 +93,223 @@ function createLocation(fileUri: string, sourceRange: SourceRange): Location {
   };
 }
 
+// Builtin symbols are identical for every SymbolTable instance and only vary by
+// locale (which affects descriptions). Build them once per locale and reuse the
+// cached array so a single document edit never rebuilds ~40 builtins from scratch.
+const builtinSymbolCache = new Map<string, SymbolInfo[]>();
+
+// What a single document contributed to the merged symbol table. Caching the
+// already-built SymbolInfo objects lets us re-derive the merged view on removal
+// without re-processing every other document's AST.
+interface DocumentContribution {
+  types: SymbolInfo[];
+  constants: SymbolInfo[];
+  imports: ImportDefinition[];
+}
+
+// Map a builtin's category to its LSP SymbolKind.
+function builtinSymbolKind(category: BuiltinTypeInfo['category']): SymbolKind {
+  switch (category) {
+    case 'primitive':
+      return SymbolKind.Struct;
+    case 'quantum':
+    case 'collection':
+    case 'special':
+    default:
+      return SymbolKind.Class;
+  }
+}
+
+function createBuiltinSymbol(builtin: BuiltinTypeInfo): SymbolInfo {
+  return {
+    name: builtin.name,
+    kind: builtinSymbolKind(builtin.category),
+    location: {
+      uri: 'builtin://',
+      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+    },
+    detail: getDescription(builtin, getLocale()),
+    children: [],
+    source: 'builtin',
+  };
+}
+
+// Builtin symbols for the active locale, computed once and memoized per locale.
+function getBuiltinSymbols(): SymbolInfo[] {
+  const locale = getLocale();
+  let symbols = builtinSymbolCache.get(locale);
+  if (!symbols) {
+    symbols = ALL_BUILTIN_TYPES.map(createBuiltinSymbol);
+    builtinSymbolCache.set(locale, symbols);
+  }
+  return symbols;
+}
+
 // Symbol Table class
 export class SymbolTable {
   types: Map<string, SymbolInfo> = new Map();
   constants: Map<string, SymbolInfo> = new Map();
   imports: ImportDefinition[] = [];
 
-  // Build symbol table from parsed QTN document
-  buildFromDocument(doc: QtnDocument): void {
-    this.types.clear();
-    this.constants.clear();
-    this.imports = [];
+  // Per-document contributions, in insertion order. Used to re-derive the merged
+  // maps incrementally when a single document is added, updated, or removed.
+  private contributions: Map<string, DocumentContribution> = new Map();
+  private builtinsMerged = false;
 
+  // Build symbol table from a single document, discarding any prior state.
+  buildFromDocument(doc: QtnDocument): void {
+    const hadBuiltins = this.builtinsMerged;
+    this.contributions.clear();
+    this.indexDocument(doc);
+    this.builtinsMerged = hadBuiltins;
+    this.rebuildMergedView();
+  }
+
+  // Add symbols from a document WITHOUT clearing existing symbols.
+  // Re-indexing the same uri replaces only that document's contribution; symbols
+  // from other documents and the builtins are left untouched.
+  addFromDocument(doc: QtnDocument): void {
+    const previous = this.contributions.get(doc.uri);
+    this.indexDocument(doc);
+    const next = this.contributions.get(doc.uri)!;
+
+    // Re-editing a document can drop names it used to define (un-shadowing a
+    // builtin or another document) or collide with another document's winner —
+    // those cases can't be resolved by a forward merge alone, so fall back to a
+    // re-derive. The re-derive only iterates cached SymbolInfo objects, never
+    // re-parses.
+    if (this.needsFullRederive(doc.uri, previous, next)) {
+      this.rebuildMergedView();
+      return;
+    }
+
+    // Common keystroke case: this document's names are a superset of before and
+    // don't collide with other documents, so applying its fresh symbols on top
+    // keeps last-write-wins correct without touching any other document.
+    // O(symbols in this one document).
+    this.applyContribution(next);
+  }
+
+  // Drop a single document's symbols. Because removal can un-shadow builtins or
+  // symbols from other documents, the merged maps are re-derived from the cached
+  // contributions rather than mutated in place.
+  removeDocument(uri: string): void {
+    if (!this.contributions.delete(uri)) {
+      return;
+    }
+    this.rebuildMergedView();
+  }
+
+  // A forward-only merge writes this document's fresh symbols straight into the
+  // live maps. That is only valid when it can't disturb another source's winner,
+  // so we fall back to a full re-derive (which still reuses cached SymbolInfo,
+  // never re-parses) in these cases:
+  //   - the re-edit removed a name it used to define (may un-shadow a builtin or
+  //     another document),
+  //   - the document declared imports (appended into a shared array; a clean
+  //     rebuild avoids leaving stale entries),
+  //   - one of the document's names is currently owned by a *different* document
+  //     (forward-merging would override that document's winner and break the
+  //     insertion-order last-write-wins rule).
+  private needsFullRederive(
+    uri: string,
+    previous: DocumentContribution | undefined,
+    next: DocumentContribution,
+  ): boolean {
+    if (previous?.imports.length || next.imports.length) {
+      return true;
+    }
+
+    if (previous) {
+      const nextTypeNames = new Set(next.types.map((s) => s.name));
+      for (const symbol of previous.types) {
+        if (!nextTypeNames.has(symbol.name)) {
+          return true;
+        }
+      }
+      const nextConstNames = new Set(next.constants.map((s) => s.name));
+      for (const symbol of previous.constants) {
+        if (!nextConstNames.has(symbol.name)) {
+          return true;
+        }
+      }
+    }
+
+    for (const symbol of next.types) {
+      if (this.ownedByOtherDocument(this.types.get(symbol.name), uri)) {
+        return true;
+      }
+    }
+    for (const symbol of next.constants) {
+      if (this.ownedByOtherDocument(this.constants.get(symbol.name), uri)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // True when the current winner for a name belongs to a different document, so a
+  // forward merge must not clobber it. Builtins (and an absent winner) are safe to
+  // overwrite by a user/import symbol, matching last-write-wins.
+  private ownedByOtherDocument(current: SymbolInfo | undefined, uri: string | undefined): boolean {
+    if (!current || current.source === 'builtin') {
+      return false;
+    }
+    return current.location.uri !== uri;
+  }
+
+  // Process the document's definitions into cached SymbolInfo objects, replacing
+  // any prior contribution for the same uri.
+  private indexDocument(doc: QtnDocument): void {
+    this.current = { types: [], constants: [], imports: [] };
     for (const def of doc.definitions) {
       this.processDefinition(def, doc.uri);
     }
+    this.contributions.set(doc.uri, this.current);
+    this.current = null;
   }
 
-  // Add symbols from a document WITHOUT clearing existing symbols
-  // Used by ProjectModel to incrementally build symbol table from multiple documents
-  addFromDocument(doc: QtnDocument): void {
-    for (const def of doc.definitions) {
-      this.processDefinition(def, doc.uri);
+  // Active contribution being populated by processDefinition during indexDocument.
+  private current: DocumentContribution | null = null;
+
+  // Re-derive the merged maps from builtins + all cached contributions, in
+  // insertion order so user definitions win over builtins and later documents
+  // win over earlier ones — exactly matching the previous full rebuild. Cheap
+  // because it reuses already-built SymbolInfo objects and cached builtins.
+  private rebuildMergedView(): void {
+    this.types = new Map();
+    this.constants = new Map();
+    this.imports = [];
+
+    if (this.builtinsMerged) {
+      for (const symbol of getBuiltinSymbols()) {
+        this.types.set(symbol.name, symbol);
+      }
+    }
+
+    for (const contribution of this.contributions.values()) {
+      this.applyContribution(contribution);
+    }
+  }
+
+  private applyContribution(contribution: DocumentContribution): void {
+    for (const symbol of contribution.types) {
+      // Imports never override an already-resolved non-import symbol (builtin,
+      // user, or import from another document) — same rule as the old inline
+      // processImportDefinition check.
+      if (symbol.source === 'import') {
+        const existing = this.types.get(symbol.name);
+        if (existing && existing.source !== 'import') {
+          continue;
+        }
+      }
+      this.types.set(symbol.name, symbol);
+    }
+    for (const symbol of contribution.constants) {
+      this.constants.set(symbol.name, symbol);
+    }
+    for (const imp of contribution.imports) {
+      this.imports.push(imp);
     }
   }
 
@@ -142,11 +337,11 @@ export class SymbolTable {
         this.processGlobalDefinition(def as GlobalDefinition, fileUri);
         break;
       case 'import':
-        this.imports.push(def as ImportDefinition);
+        this.emitImport(def as ImportDefinition);
         this.processImportDefinition(def as ImportDefinition, fileUri);
         break;
       case 'using':
-        this.imports.push(def as ImportDefinition);
+        this.emitImport(def as ImportDefinition);
         break;
       case 'define':
         this.processDefineDefinition(def as DefineDefinition, fileUri);
@@ -157,12 +352,9 @@ export class SymbolTable {
     }
   }
 
+  // Emit an import symbol into the current contribution. The decision to skip it
+  // when a non-import symbol already wins is applied later in applyContribution.
   private processImportDefinition(def: ImportDefinition, fileUri: string): void {
-    const existing = this.types.get(def.name);
-    if (existing && existing.source !== 'import') {
-      return;
-    }
-
     const symbol: SymbolInfo = {
       name: def.name,
       kind: this.importKindToSymbolKind(def.importKind),
@@ -172,7 +364,20 @@ export class SymbolTable {
       source: 'import',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
+  }
+
+  // Collect emitted symbols into the contribution being indexed.
+  private emitType(symbol: SymbolInfo): void {
+    this.current?.types.push(symbol);
+  }
+
+  private emitConstant(symbol: SymbolInfo): void {
+    this.current?.constants.push(symbol);
+  }
+
+  private emitImport(def: ImportDefinition): void {
+    this.current?.imports.push(def);
   }
 
   private importKindToSymbolKind(kind: ImportDefinition['importKind']): SymbolKind {
@@ -228,7 +433,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process event definition
@@ -252,7 +457,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process signal definition
@@ -268,7 +473,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process input definition
@@ -290,7 +495,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set('input', symbol);
+    this.emitType(symbol);
   }
 
   // Process global definition
@@ -312,7 +517,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set('global', symbol);
+    this.emitType(symbol);
   }
 
   // Process #define constant
@@ -326,7 +531,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.constants.set(def.name, symbol);
+    this.emitConstant(symbol);
   }
 
   // Create field symbol
@@ -355,48 +560,16 @@ export class SymbolTable {
     };
   }
 
-  // Pre-populate symbol table with built-in types
+  // Pre-populate symbol table with built-in types. Reuses the per-locale cached
+  // builtin symbols instead of recreating them on every call.
   mergeBuiltins(): void {
-    for (const builtin of ALL_BUILTIN_TYPES) {
-      const symbol = this.createBuiltinSymbol(builtin);
+    this.builtinsMerged = true;
+    for (const symbol of getBuiltinSymbols()) {
       // Don't overwrite user-defined types
       if (!this.types.has(symbol.name)) {
         this.types.set(symbol.name, symbol);
       }
     }
-  }
-
-  // Create symbol from builtin type info
-  private createBuiltinSymbol(builtin: BuiltinTypeInfo): SymbolInfo {
-    let kind: SymbolKind;
-    switch (builtin.category) {
-      case 'primitive':
-        kind = SymbolKind.Struct;
-        break;
-      case 'quantum':
-        kind = SymbolKind.Class;
-        break;
-      case 'collection':
-        kind = SymbolKind.Class;
-        break;
-      case 'special':
-        kind = SymbolKind.Class;
-        break;
-      default:
-        kind = SymbolKind.Class;
-    }
-
-    return {
-      name: builtin.name,
-      kind,
-      location: {
-        uri: 'builtin://',
-        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-      },
-      detail: getDescription(builtin, getLocale()),
-      children: [],
-      source: 'builtin',
-    };
   }
 
   // Lookup symbol by exact name


### PR DESCRIPTION
## Problem
`ProjectModel.rebuildSymbolTable()` ran on every `updateDocument`/`removeDocument`. It discarded the whole `SymbolTable`, re-ran `mergeBuiltins()` (re-allocating ~40+ builtin types each time), and re-ran `addFromDocument()` for every document in the project. Because the server indexes every workspace `.qtn` file, a single keystroke in one file re-processed the entire project — O(total symbols across all files) per change.

## Root cause
The symbol table had no notion of which document a symbol came from, so the only way to stay consistent after any edit was a full teardown + rebuild from all parsed documents, plus a fresh builtin merge.

## Fix
- Build builtin symbols once per locale and memoize them; reuse the cached, read-only objects instead of recreating them on every change.
- Track each document's contribution (`Map<uri, {types, constants, imports}>`). `addFromDocument` re-indexes only the changed uri; the common keystroke case is an O(symbols-in-that-doc) forward merge, falling back to re-deriving the merged view (still from cached symbols, no re-parse) only when an edit removes a name, touches imports, or collides with another document's winner.
- Add `SymbolTable.removeDocument(uri)` so closing/deleting a file drops only that file's symbols and correctly restores any builtin or other-document definition it had shadowed.
- Drop the `dirty`-flag / `rebuildSymbolTable` path from `ProjectModel`; the table is now maintained incrementally.

Observable behavior (lookup, getAllSymbols, findDefinition, document/workspace symbols, fuzzy search, builtin/import precedence) is unchanged.

## Testing
- New `incremental-symbol-table.test.ts` (7 tests) proving the incremental property: editing doc A keeps doc B's symbols, builtins persist across edits, `removeDocument` removes only the target doc and restores shadowed builtins, later-document winners survive re-editing an earlier colliding document, and removed names are evicted.
- Full unit suite green: 53 passed (46 baseline + 7 new).
- Integration suite green: 8 passed (builds and drives the compiled server).
- `tsc --noEmit` clean.
