### PR TITLE
fix: nullable type reference name mutation breaking symbol lookups

### DIFF
--- a/language-server/src/__tests__/hover.test.ts
+++ b/language-server/src/__tests__/hover.test.ts
@@ -43,6 +43,18 @@ component P {
     expect(value).toContain('test.qtn');
   });
 
+  it('resolves a nullable user-defined type to its declaration site', () => {
+    const source = `struct Stats { }
+component P {
+  Stats? S;
+}`;
+    // Cursor on 'Stats' in the nullable field type.
+    const value = hoverText(source, 2, 4);
+    expect(value).not.toBeNull();
+    // Keeping the original name (not 'NullableStats') lets the lookup resolve.
+    expect(value).toContain('test.qtn');
+  });
+
   it('returns null when the cursor is not on an identifier', () => {
     // Leading blank line: offset 0 sits on a newline, no identifier to resolve.
     expect(hoverText('\ncomponent P {}', 0, 0)).toBeNull();

--- a/language-server/src/__tests__/parser-edge-cases.test.ts
+++ b/language-server/src/__tests__/parser-edge-cases.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { parse } from '../parser.js';
+import { TypeDefinition } from '../ast.js';
 
 describe('Parser Edge Cases', () => {
   it('should handle empty files without errors', () => {
@@ -192,5 +193,24 @@ describe('Parser Edge Cases', () => {
 
     // Will have errors
     expect(result.parseErrors.length).toBeGreaterThan(0);
+  });
+
+  it('should record nullable suffix without mutating the type name', () => {
+    const result = parse('struct S { FP? Maybe; }', 'test://nullable.qtn');
+    const struct = result.definitions.find(d => d.kind === 'struct') as TypeDefinition;
+    const typeRef = struct.fields[0].typeRef;
+
+    // Name stays the source name (NOT 'NullableFP') so symbol lookups resolve.
+    expect(typeRef.name).toBe('FP');
+    expect(typeRef.isNullable).toBe(true);
+    // nameRange covers only 'FP', not the trailing '?'.
+    const nameLen = typeRef.nameRange.end.character - typeRef.nameRange.start.character;
+    expect(nameLen).toBe('FP'.length);
+  });
+
+  it('should leave isNullable false for non-nullable types', () => {
+    const result = parse('struct S { FP Value; }', 'test://non-nullable.qtn');
+    const struct = result.definitions.find(d => d.kind === 'struct') as TypeDefinition;
+    expect(struct.fields[0].typeRef.isNullable).toBe(false);
   });
 });

--- a/language-server/src/__tests__/semantic-tokens.test.ts
+++ b/language-server/src/__tests__/semantic-tokens.test.ts
@@ -200,6 +200,23 @@ event MyEvent {
     expect(tokens).toHaveLength(0);
   });
 
+  it('should emit a correctly-sized token for a nullable user-defined type', () => {
+    const source = `
+struct Health { }
+component Player {
+  Health? Maybe;
+}`;
+    const result = getTokens(source);
+    expect(result).not.toBeNull();
+
+    const tokens = decodeTokens(result!.data);
+    // The nullable 'Health?' field type resolves to the user-defined struct and
+    // the token must span exactly 'Health' (6 chars), not 'NullableHealth' (14).
+    const structTokens = tokens.filter(t => t.tokenType === tokenTypes.indexOf('struct'));
+    expect(structTokens.length).toBeGreaterThanOrEqual(1);
+    expect(structTokens.every(t => t.length === 'Health'.length)).toBe(true);
+  });
+
   it('should handle nameRange correctly for multiline token positions', () => {
     const source = `
 struct StateA { }

--- a/language-server/src/ast.ts
+++ b/language-server/src/ast.ts
@@ -36,6 +36,7 @@ export interface TypeReference {
   genericArgs: TypeArgument[];
   arraySize?: number;  // fixed array size: array<T>[N]
   isPointer: boolean;  // signal parameter pointer: *
+  isNullable: boolean; // nullable suffix: Type?
   range: SourceRange;
 }
 

--- a/language-server/src/parser.ts
+++ b/language-server/src/parser.ts
@@ -1038,13 +1038,11 @@ class Parser {
       this.expect(TokenType.punctuation, ']');
     }
 
-    // Nullable suffix: FP? → becomes NullableFP conceptually, but
-    // we store it as the original name with `?` appended for downstream.
-    // Actually the AST TypeReference doesn't have an isNullable flag.
-    // The DSL maps FP? → NullableFP at codegen. For the parser we record
-    // it as the name with a nullable indicator. Let's just rename it.
+    // Nullable suffix: FP? — keep the original name so symbol lookups and
+    // nameRange stay accurate. The DSL maps it to NullableFP at codegen.
+    let isNullable = false;
     if (this.match(TokenType.punctuation, '?')) {
-      name = 'Nullable' + name;
+      isNullable = true;
     }
 
     // Pointer suffix: Type* (used in signal params)
@@ -1061,6 +1059,7 @@ class Parser {
       genericArgs,
       arraySize,
       isPointer,
+      isNullable,
       range: this.makeRange(startRange, endRange),
     };
   }

--- a/language-server/src/semantic-tokens.ts
+++ b/language-server/src/semantic-tokens.ts
@@ -144,11 +144,18 @@ export function handleSemanticTokensFull(
 
       const tokenType = symbolKindToTokenType(symbol.kind);
 
-      // Use name.length for correct token length (handles multiline dotted names)
+      // Derive length from nameRange so it stays correct regardless of how the
+      // name was stored (e.g. nullable types). Fall back to name.length for
+      // multiline dotted names where columns span lines.
+      const { start, end } = typeRef.nameRange;
+      const length = start.line === end.line
+        ? end.character - start.character
+        : typeRef.name.length;
+
       tokens.push({
-        line: typeRef.nameRange.start.line,
-        char: typeRef.nameRange.start.character,
-        length: typeRef.name.length,
+        line: start.line,
+        char: start.character,
+        length,
         tokenType,
         tokenModifiers: 0,
       });


### PR DESCRIPTION
## Problem
For a nullable field type like `FP?`, the parser stored the type name as `NullableFP`. Consequences:
- `symbolTable.lookup(typeRef.name)` looked up `NullableX`, which never resolves for user-defined types — semantic-token highlighting silently failed for nullable fields.
- `nameRange` still covered only the original name, but `semantic-tokens.ts` used `length: typeRef.name.length`, so the emitted token was 8 chars ("Nullable") too long.

## Root cause
`parser.ts` did `name = 'Nullable' + name` on the `?` suffix (an admitted hack), so `TypeReference.name` no longer matched the source token or `nameRange`.

## Fix
- Added `isNullable: boolean` to the `TypeReference` AST node.
- Parser now sets `isNullable = true` on the `?` suffix and keeps the original type name.
- `semantic-tokens.ts` computes token length from `nameRange` (`end.character - start.character` on a single line; `name.length` fallback for multiline dotted names), fixing the length regression and staying correct for nullable types.

Quantum builtins (`NullableFP`, etc.) are written literally in `builtins.ts`, not via `?`, so they are unaffected.

## Testing
- New parser tests: `FP?` yields `name === 'FP'`, `isNullable === true`, `nameRange` spans only `FP`; non-nullable types keep `isNullable === false`.
- New semantic-tokens test: nullable user-defined field emits a token of the correct length (6 for `Health`, not 14).
- New hover test: nullable user-defined type resolves to its declaration site.
- Full unit suite green: 50 passed (46 baseline + 4 new). `tsc --noEmit` clean.
