### PR TITLE
feat: publish syntax diagnostics and detect unterminated literals

### DIFF
--- a/language-server/src/__tests__/diagnostics.test.ts
+++ b/language-server/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,71 @@
+// Tests for the pure parseErrors -> LSP Diagnostic[] conversion and for
+// surfacing lexer-level unterminated string/comment errors as parse errors.
+
+import { describe, it, expect } from 'vitest';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { diagnosticsForDocument, DIAGNOSTIC_SOURCE } from '../diagnostics.js';
+import { parse } from '../parser.js';
+import type { QtnDocument } from '../ast.js';
+
+function docWith(parseErrors: QtnDocument['parseErrors']): QtnDocument {
+  return { uri: 'test://doc.qtn', version: 0, definitions: [], parseErrors };
+}
+
+describe('diagnosticsForDocument', () => {
+  it('returns an empty array when there are no parse errors', () => {
+    expect(diagnosticsForDocument(docWith([]))).toEqual([]);
+  });
+
+  it('maps each parse error to an Error-severity diagnostic with source qtn', () => {
+    const range = { start: { line: 2, character: 4 }, end: { line: 2, character: 9 } };
+    const diagnostics = diagnosticsForDocument(docWith([{ message: 'boom', range }]));
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      severity: DiagnosticSeverity.Error,
+      message: 'boom',
+      source: DIAGNOSTIC_SOURCE,
+      range,
+    });
+  });
+
+  it('preserves order and count for multiple errors', () => {
+    const r = { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } };
+    const diagnostics = diagnosticsForDocument(
+      docWith([
+        { message: 'first', range: r },
+        { message: 'second', range: r },
+      ]),
+    );
+    expect(diagnostics.map((d) => d.message)).toEqual(['first', 'second']);
+  });
+
+  it('produces diagnostics end-to-end from a real parse with a syntax error', () => {
+    const doc = parse('struct Foo {', 'test://incomplete.qtn');
+    const diagnostics = diagnosticsForDocument(doc);
+    expect(diagnostics.length).toBeGreaterThan(0);
+    expect(diagnostics.every((d) => d.severity === DiagnosticSeverity.Error)).toBe(true);
+    expect(diagnostics.every((d) => d.source === DIAGNOSTIC_SOURCE)).toBe(true);
+  });
+});
+
+describe('lexer-level errors surface in parseErrors', () => {
+  it('reports an unterminated string literal', () => {
+    const doc = parse('struct Foo { } [Header("oops]', 'test://unterminated-string.qtn');
+    expect(
+      doc.parseErrors.some((e) => /unterminated string/i.test(e.message)),
+    ).toBe(true);
+  });
+
+  it('reports an unterminated block comment', () => {
+    const doc = parse('/* never closed\nstruct Foo { }', 'test://unterminated-comment.qtn');
+    expect(
+      doc.parseErrors.some((e) => /unterminated block comment/i.test(e.message)),
+    ).toBe(true);
+  });
+
+  it('does not report unterminated errors for well-formed input', () => {
+    const doc = parse('/* fine */ struct Foo { FP x; } // "quoted"', 'test://clean.qtn');
+    expect(doc.parseErrors.some((e) => /unterminated/i.test(e.message))).toBe(false);
+  });
+});

--- a/language-server/src/ast.ts
+++ b/language-server/src/ast.ts
@@ -152,7 +152,7 @@ export type Definition =
   | PragmaDefinition
   | DefineDefinition;
 
-// Parse error (internal, no diagnostics published)
+// Parse/lex error surfaced to the editor as an LSP diagnostic.
 export interface ParseError {
   message: string;
   range: SourceRange;

--- a/language-server/src/diagnostics.ts
+++ b/language-server/src/diagnostics.ts
@@ -1,0 +1,25 @@
+// Converts QTN parse/lex errors into LSP diagnostics.
+// Kept pure (no LSP connection) so it can be unit-tested in isolation.
+
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { QtnDocument, ParseError } from './ast.js';
+
+export const DIAGNOSTIC_SOURCE = 'qtn';
+
+/** Convert a single parse error into an LSP diagnostic. */
+function toDiagnostic(error: ParseError): Diagnostic {
+  return {
+    severity: DiagnosticSeverity.Error,
+    range: error.range,
+    message: error.message,
+    source: DIAGNOSTIC_SOURCE,
+  };
+}
+
+/**
+ * Build the diagnostic list for a parsed document. Returns an empty array
+ * when there are no parse errors so callers can clear stale diagnostics.
+ */
+export function diagnosticsForDocument(doc: QtnDocument): Diagnostic[] {
+  return doc.parseErrors.map(toDiagnostic);
+}

--- a/language-server/src/lexer.ts
+++ b/language-server/src/lexer.ts
@@ -1,5 +1,5 @@
 // QTN Lexer - Token stream generator for QTN parser
-import { Position, SourceRange } from './ast.js';
+import { Position, SourceRange, ParseError } from './ast.js';
 
 // Token types
 export enum TokenType {
@@ -44,6 +44,7 @@ class Lexer {
   private line: number;
   private character: number;
   private tokens: QtnToken[];
+  private errors: ParseError[];
 
   constructor(text: string) {
     this.text = text;
@@ -51,6 +52,11 @@ class Lexer {
     this.line = 0;
     this.character = 0;
     this.tokens = [];
+    this.errors = [];
+  }
+
+  getErrors(): ParseError[] {
+    return this.errors;
   }
 
   // Get current character
@@ -119,6 +125,7 @@ class Lexer {
 
   // Skip multi-line comment: /* ... */
   private skipBlockComment(): void {
+    const start = this.currentPosition();
     // Skip /*
     this.advance();
     this.advance();
@@ -129,16 +136,23 @@ class Lexer {
       if (ch === '*' && this.peek() === '/') {
         this.advance(); // skip *
         this.advance(); // skip /
-        break;
+        return;
       }
       this.advance();
     }
+
+    // Reached EOF without a closing */
+    this.errors.push({
+      message: 'Unterminated block comment',
+      range: { start, end: this.currentPosition() },
+    });
   }
 
   // Read string literal: "..."
   private readString(): QtnToken {
     const start = this.currentPosition();
     let value = '';
+    let terminated = false;
 
     // Skip opening quote
     this.advance();
@@ -149,6 +163,7 @@ class Lexer {
       if (ch === '"') {
         // End of string
         this.advance();
+        terminated = true;
         break;
       } else if (ch === '\\') {
         // Escape sequence
@@ -179,6 +194,14 @@ class Lexer {
     }
 
     const end = this.currentPosition();
+
+    if (!terminated) {
+      this.errors.push({
+        message: 'Unterminated string literal',
+        range: { start, end },
+      });
+    }
+
     return {
       type: TokenType.string,
       value,
@@ -426,8 +449,21 @@ class Lexer {
   }
 }
 
+// Result of tokenizing with lexer-level diagnostics attached.
+export interface LexResult {
+  tokens: QtnToken[];
+  errors: ParseError[];
+}
+
 // Main entry point
 export function tokenize(text: string): QtnToken[] {
   const lexer = new Lexer(text);
   return lexer.tokenize();
+}
+
+// Tokenize and also surface lexer errors (unterminated strings/comments).
+export function tokenizeWithErrors(text: string): LexResult {
+  const lexer = new Lexer(text);
+  const tokens = lexer.tokenize();
+  return { tokens, errors: lexer.getErrors() };
 }

--- a/language-server/src/parser.ts
+++ b/language-server/src/parser.ts
@@ -2,7 +2,7 @@
 // Converts token stream from lexer into AST (ast.ts nodes).
 // Implements panic-mode error recovery: on parse errors, skips to }, ;, or top-level keyword.
 
-import { tokenize, QtnToken, TokenType } from './lexer.js';
+import { tokenizeWithErrors, QtnToken, TokenType } from './lexer.js';
 import {
   type SourceRange,
   type Position,
@@ -52,11 +52,13 @@ class Parser {
   private fileUri: string;
   private errors: ParseError[];
 
-  constructor(tokens: QtnToken[], fileUri: string) {
+  constructor(tokens: QtnToken[], fileUri: string, initialErrors: ParseError[] = []) {
     this.tokens = tokens;
     this.pos = 0;
     this.fileUri = fileUri;
-    this.errors = [];
+    // Lexer-level errors (unterminated strings/comments) are seeded first so
+    // they surface alongside parse errors in the resulting QtnDocument.
+    this.errors = [...initialErrors];
   }
 
   // ── Token helpers ──────────────────────────────────────────────
@@ -1219,7 +1221,7 @@ class Parser {
 // ── Public API ─────────────────────────────────────────────────────
 
 export function parse(text: string, fileUri: string): QtnDocument {
-  const tokens = tokenize(text);
-  const parser = new Parser(tokens, fileUri);
+  const { tokens, errors } = tokenizeWithErrors(text);
+  const parser = new Parser(tokens, fileUri, errors);
   return parser.parse();
 }

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -21,6 +21,7 @@ import { handleHover } from './hover.js';
 import { handleDocumentSymbol, handleWorkspaceSymbol } from './symbols.js';
 import { handleSemanticTokensFull, tokenTypes, tokenModifiers } from './semantic-tokens.js';
 import { setLocale } from './locale.js';
+import { diagnosticsForDocument } from './diagnostics.js';
 
 // Create LSP connection using Node IPC
 const connection = createConnection(ProposedFeatures.all);
@@ -84,12 +85,29 @@ connection.onInitialized(() => {
 // Document change handler - update project model when documents change
 documents.onDidChangeContent((change) => {
   projectModel.updateDocument(change.document.uri, change.document.getText());
+  publishDiagnostics(change.document.uri);
 });
 
 // Document close handler - keep workspace files indexed from disk.
 documents.onDidClose((event) => {
+  // The buffer is gone from the editor; clear its diagnostics. If the file
+  // still exists on disk, reloadClosedDocument re-publishes from disk content.
+  clearDiagnostics(event.document.uri);
   void reloadClosedDocument(event.document.uri);
 });
+
+// Publish syntax diagnostics for a parsed document. Sends an empty array to
+// clear when there are no errors. Safe to call only after the document has
+// been (re)parsed into the project model.
+function publishDiagnostics(uri: string): void {
+  const doc = projectModel.getDocument(uri);
+  const diagnostics = doc ? diagnosticsForDocument(doc) : [];
+  void connection.sendDiagnostics({ uri, diagnostics });
+}
+
+function clearDiagnostics(uri: string): void {
+  void connection.sendDiagnostics({ uri, diagnostics: [] });
+}
 
 // Handle workspace file changes (external edits, file creation/deletion)
 connection.onDidChangeWatchedFiles((params) => {
@@ -99,6 +117,7 @@ connection.onDidChangeWatchedFiles((params) => {
     switch (change.type) {
       case FileChangeType.Deleted:
         projectModel.removeDocument(change.uri);
+        clearDiagnostics(change.uri);
         break;
       case FileChangeType.Created:
       case FileChangeType.Changed:
@@ -158,6 +177,7 @@ async function loadFileIntoProject(uri: string): Promise<void> {
   const openDocument = documents.get(uri);
   if (openDocument) {
     projectModel.updateDocument(uri, openDocument.getText());
+    publishDiagnostics(uri);
     return;
   }
 
@@ -169,9 +189,11 @@ async function loadFileIntoProject(uri: string): Promise<void> {
   try {
     const text = await fs.readFile(filePath, 'utf8');
     projectModel.updateDocument(uri, text);
+    publishDiagnostics(uri);
   } catch (error) {
     if (isMissingFileError(error)) {
       projectModel.removeDocument(uri);
+      clearDiagnostics(uri);
       return;
     }
 


### PR DESCRIPTION
## Problem
The parser already produced `parseErrors` on every `QtnDocument`, but `server.ts` never called `connection.sendDiagnostics`, so users never saw syntax errors in any IDE. Separately, the lexer silently swallowed unterminated block comments and unterminated string literals at EOF, so those mistakes produced no error at all.

## Root cause
- No diagnostics wiring existed in the server's document lifecycle handlers.
- `Lexer.skipBlockComment` and `Lexer.readString` exited their loops at EOF without recording any error, and the lexer had no channel to report errors into `parseErrors`.

## Fix
- New pure `diagnostics.ts`: `diagnosticsForDocument(doc)` converts `parseErrors` → `Diagnostic[]` (`Error` severity, `source: 'qtn'`), returning `[]` to clear when clean.
- Lexer now collects errors for unterminated strings/comments; new `tokenizeWithErrors` exposes them and the parser seeds them into `parseErrors`. The original `tokenize` is preserved for backward compatibility.
- `server.ts` publishes diagnostics after parse on content change and on (re)load, and clears them on close, deletion, and missing files. Wiring is thin; `connection.listen()` and exports are unchanged.

## Testing
- `cd language-server && npx vitest run` → 53 passed (46 baseline + 7 new).
- `npx tsc --noEmit` → clean.
- New tests cover the pure conversion function and that an unterminated string and an unterminated block comment each surface as a parse/lex error (plus a negative case for well-formed input).
