### PR TITLE
fix: await client.start() and surface language server errors to user

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { workspace, ExtensionContext, env } from 'vscode';
+import { workspace, ExtensionContext, env, window } from 'vscode';
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -9,7 +9,7 @@ import {
 
 let client: LanguageClient | undefined;
 
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
   // Path to the language server module (bundled)
   const serverModule = path.join(
     context.extensionPath,
@@ -42,7 +42,14 @@ export function activate(context: ExtensionContext) {
     clientOptions
   );
 
-  client.start();
+  try {
+    await client.start();
+  } catch (err) {
+    console.error('QTN language server failed to start:', err);
+    void window.showErrorMessage(
+      `QTN Language Server failed to start: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
## Problem
`activate()` called `client.start()` without `await` and without any error handling. In `vscode-languageclient` v9, `start()` returns a Promise that rejects when the language server fails to spawn.

## Root cause
The unhandled rejection was silently swallowed by the VS Code extension host, so activation failures were invisible to the user — LSP features simply stopped working with no indication of why.

## Fix
- Made `activate` async.
- `await`-ed `client.start()` inside a `try/catch`.
- On failure, logs the error to the console and calls `window.showErrorMessage(...)` so the user sees a clear notification that the QTN Language Server failed to start, including the underlying error message.
- Added `window` to the `vscode` import (was missing).

## Testing
- `npx tsc -p . --noEmit` passes with no errors.
- No runtime unit tests exist for the extension activation path; the fix follows the standard VS Code extension error-handling pattern.
