### PR TITLE
refactor: extract escape-aware bracket scanner and fix escaped-quote detection

### DIFF
--- a/language-server/src/__tests__/completion.test.ts
+++ b/language-server/src/__tests__/completion.test.ts
@@ -58,4 +58,21 @@ component Player {
     const labels = complete(source, 1, 7);
     expect(labels).toEqual(expect.arrayContaining(['FP', 'int']));
   });
+
+  it('attribute string ending in an escaped backslash does not leak attribute context', () => {
+    // The string literal is "a\\" — an escaped backslash before the real closing
+    // quote. A naive one-char escape check mistakes the closing quote for an
+    // escaped one, leaving the scanner "in string" so the ']' is never counted
+    // and the bracket looks unmatched. The line below should be field-type, not
+    // attribute, context.
+    const source = `component Player {
+  [Header("a\\\\")]
+
+}`;
+    const labels = complete(source, 2, 2);
+    expect(labels).toEqual(expect.arrayContaining(['FP', 'int']));
+    expect(labels).not.toEqual(
+      expect.arrayContaining(ATTRIBUTES.map((a) => a.name)),
+    );
+  });
 });

--- a/language-server/src/completion.ts
+++ b/language-server/src/completion.ts
@@ -23,6 +23,7 @@ import {
 } from './builtins.js';
 import { getLocale } from './locale.js';
 import { nodeKindToSymbolKind } from './symbol-table.js';
+import { scanBrackets } from './text-navigation.js';
 
 // Completion context types
 type CompletionContext =
@@ -128,57 +129,7 @@ function detectContext(
  * Check if there's an unmatched '[' (inside attribute)
  */
 function hasUnmatchedOpenBracket(text: string): boolean {
-  let openCount = 0;
-  let inString = false;
-  let inLineComment = false;
-  let inBlockComment = false;
-
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    const next = text[i + 1];
-
-    // Handle comments
-    if (!inString && !inBlockComment && ch === '/' && next === '/') {
-      inLineComment = true;
-      i++;
-      continue;
-    }
-    if (!inString && !inLineComment && ch === '/' && next === '*') {
-      inBlockComment = true;
-      i++;
-      continue;
-    }
-    if (inBlockComment && ch === '*' && next === '/') {
-      inBlockComment = false;
-      i++;
-      continue;
-    }
-    if (inLineComment && (ch === '\n' || ch === '\r')) {
-      inLineComment = false;
-      continue;
-    }
-
-    // Skip if in comment
-    if (inLineComment || inBlockComment) continue;
-
-    // Handle strings
-    if (ch === '"' && (i === 0 || text[i - 1] !== '\\')) {
-      inString = !inString;
-      continue;
-    }
-
-    // Skip if in string
-    if (inString) continue;
-
-    // Count brackets
-    if (ch === '[') {
-      openCount++;
-    } else if (ch === ']') {
-      openCount--;
-    }
-  }
-
-  return openCount > 0;
+  return scanBrackets(text).squareDepth > 0;
 }
 
 /**
@@ -264,30 +215,8 @@ function isInsideInputBlock(text: string, offset: number): boolean {
  * Check if in field type position (inside block, after '{' or ';')
  */
 function isFieldTypePosition(text: string, offset: number): boolean {
-  // Look for unmatched '{' without a closing '}'
-  let braceDepth = 0;
-  let inString = false;
-
-  for (let i = 0; i < offset; i++) {
-    const ch = text[i];
-
-    // Handle strings
-    if (ch === '"' && (i === 0 || text[i - 1] !== '\\')) {
-      inString = !inString;
-      continue;
-    }
-
-    if (inString) continue;
-
-    if (ch === '{') {
-      braceDepth++;
-    } else if (ch === '}') {
-      braceDepth--;
-    }
-  }
-
-  // We're in field type position if we're inside a block (braceDepth > 0)
-  return braceDepth > 0;
+  // We're in field type position when the cursor sits inside an open block.
+  return scanBrackets(text.substring(0, offset)).braceDepth > 0;
 }
 
 /**

--- a/language-server/src/text-navigation.ts
+++ b/language-server/src/text-navigation.ts
@@ -37,3 +37,79 @@ export function getIdentifierAtPosition(
 export function isIdentifierChar(ch: string): boolean {
   return /[a-zA-Z0-9_]/.test(ch);
 }
+
+export interface BracketScan {
+  /** Net nesting depth of '[' minus ']' outside strings/comments. */
+  squareDepth: number;
+  /** Net nesting depth of '{' minus '}' outside strings/comments. */
+  braceDepth: number;
+}
+
+/**
+ * Single-pass scan that tracks line/block comments and string literals, then
+ * reports the net nesting depth of square brackets and curly braces in code.
+ *
+ * String parsing counts the run of consecutive backslashes before a quote: an
+ * odd run means the quote is escaped (e.g. `"...\""`), an even run (including
+ * zero) means it is a real delimiter. A naive "previous char isn't a backslash"
+ * check mis-reads a literal that ends in an escaped backslash like `"a\\"`.
+ */
+export function scanBrackets(text: string): BracketScan {
+  let squareDepth = 0;
+  let braceDepth = 0;
+  let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (!inString && !inBlockComment && ch === '/' && next === '/') {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (!inString && !inLineComment && ch === '/' && next === '*') {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (inBlockComment && ch === '*' && next === '/') {
+      inBlockComment = false;
+      i++;
+      continue;
+    }
+    if (inLineComment && (ch === '\n' || ch === '\r')) {
+      inLineComment = false;
+      continue;
+    }
+
+    if (inLineComment || inBlockComment) continue;
+
+    if (ch === '"') {
+      let backslashes = 0;
+      for (let j = i - 1; j >= 0 && text[j] === '\\'; j--) {
+        backslashes++;
+      }
+      if (backslashes % 2 === 0) {
+        inString = !inString;
+      }
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (ch === '[') {
+      squareDepth++;
+    } else if (ch === ']') {
+      squareDepth--;
+    } else if (ch === '{') {
+      braceDepth++;
+    } else if (ch === '}') {
+      braceDepth--;
+    }
+  }
+
+  return { squareDepth, braceDepth };
+}


### PR DESCRIPTION
## Problem
`completion.ts` duplicated string/comment/bracket scanning logic across `hasUnmatchedOpenBracket()` and `isFieldTypePosition()`. Both relied on the escape check `text[i - 1] !== '\\'`, which is wrong for a string literal that ends in an escaped backslash (e.g. `[Header("a\\")]`).

## Root cause
The one-char lookback treats the closing quote of `"a\\"` as escaped, because the immediately preceding character is a backslash. The scanner stays "in string" past the literal, so the closing `]` is never counted — the bracket looks unmatched and the completion context is mis-detected as `attribute` instead of `fieldType`.

## Fix
Added a single escape-aware scanner `scanBrackets()` in `text-navigation.ts` that tracks line/block comments and string state, and reports both square- and curly-bracket nesting in one pass. String parsing now counts the run of consecutive backslashes before each quote (odd ⇒ escaped, even ⇒ real delimiter). Both completion helpers now delegate to it, removing the duplicated logic and fixing the bug in one place.

## Testing
- Added a regression test for the `"a\\"` escaped-backslash case (must resolve to field-type context, not attribute context).
- `npx vitest run`: 47 passed (46 prior + 1 new).
- `npx tsc --noEmit`: clean.
