### PR TITLE
Integrate useful QTN LSP PR fixes

### DIFF
--- a/language-server/src/__tests__/completion.test.ts
+++ b/language-server/src/__tests__/completion.test.ts
@@ -58,4 +58,21 @@ component Player {
     const labels = complete(source, 1, 7);
     expect(labels).toEqual(expect.arrayContaining(['FP', 'int']));
   });
+
+  it('attribute string ending in an escaped backslash does not leak attribute context', () => {
+    // The string literal is "a\\" — an escaped backslash before the real closing
+    // quote. A naive one-char escape check mistakes the closing quote for an
+    // escaped one, leaving the scanner "in string" so the ']' is never counted
+    // and the bracket looks unmatched. The line below should be field-type, not
+    // attribute, context.
+    const source = `component Player {
+  [Header("a\\\\")]
+
+}`;
+    const labels = complete(source, 2, 2);
+    expect(labels).toEqual(expect.arrayContaining(['FP', 'int']));
+    expect(labels).not.toEqual(
+      expect.arrayContaining(ATTRIBUTES.map((a) => a.name)),
+    );
+  });
 });

--- a/language-server/src/__tests__/definition.test.ts
+++ b/language-server/src/__tests__/definition.test.ts
@@ -26,6 +26,19 @@ component P {
     expect(loc!.range.start.line).toBe(0);
   });
 
+  it('resolves a user-defined type reference prefixed with @', () => {
+    const source = `struct @Player {
+  int Hp;
+}
+component Game {
+  @Player Actor;
+}`;
+    const loc = define(source, 4, 4);
+    expect(loc).not.toBeNull();
+    expect(loc!.uri).toBe('test://test.qtn');
+    expect(loc!.range.start.line).toBe(0);
+  });
+
   it('returns null for a builtin type', () => {
     const loc = define('component P {\n  FP X;\n}', 1, 3);
     expect(loc).toBeNull();

--- a/language-server/src/__tests__/diagnostics.test.ts
+++ b/language-server/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,71 @@
+// Tests for the pure parseErrors -> LSP Diagnostic[] conversion and for
+// surfacing lexer-level unterminated string/comment errors as parse errors.
+
+import { describe, it, expect } from 'vitest';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { diagnosticsForDocument, DIAGNOSTIC_SOURCE } from '../diagnostics.js';
+import { parse } from '../parser.js';
+import type { QtnDocument } from '../ast.js';
+
+function docWith(parseErrors: QtnDocument['parseErrors']): QtnDocument {
+  return { uri: 'test://doc.qtn', version: 0, definitions: [], parseErrors };
+}
+
+describe('diagnosticsForDocument', () => {
+  it('returns an empty array when there are no parse errors', () => {
+    expect(diagnosticsForDocument(docWith([]))).toEqual([]);
+  });
+
+  it('maps each parse error to an Error-severity diagnostic with source qtn', () => {
+    const range = { start: { line: 2, character: 4 }, end: { line: 2, character: 9 } };
+    const diagnostics = diagnosticsForDocument(docWith([{ message: 'boom', range }]));
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      severity: DiagnosticSeverity.Error,
+      message: 'boom',
+      source: DIAGNOSTIC_SOURCE,
+      range,
+    });
+  });
+
+  it('preserves order and count for multiple errors', () => {
+    const r = { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } };
+    const diagnostics = diagnosticsForDocument(
+      docWith([
+        { message: 'first', range: r },
+        { message: 'second', range: r },
+      ]),
+    );
+    expect(diagnostics.map((d) => d.message)).toEqual(['first', 'second']);
+  });
+
+  it('produces diagnostics end-to-end from a real parse with a syntax error', () => {
+    const doc = parse('struct Foo {', 'test://incomplete.qtn');
+    const diagnostics = diagnosticsForDocument(doc);
+    expect(diagnostics.length).toBeGreaterThan(0);
+    expect(diagnostics.every((d) => d.severity === DiagnosticSeverity.Error)).toBe(true);
+    expect(diagnostics.every((d) => d.source === DIAGNOSTIC_SOURCE)).toBe(true);
+  });
+});
+
+describe('lexer-level errors surface in parseErrors', () => {
+  it('reports an unterminated string literal', () => {
+    const doc = parse('struct Foo { } [Header("oops]', 'test://unterminated-string.qtn');
+    expect(
+      doc.parseErrors.some((e) => /unterminated string/i.test(e.message)),
+    ).toBe(true);
+  });
+
+  it('reports an unterminated block comment', () => {
+    const doc = parse('/* never closed\nstruct Foo { }', 'test://unterminated-comment.qtn');
+    expect(
+      doc.parseErrors.some((e) => /unterminated block comment/i.test(e.message)),
+    ).toBe(true);
+  });
+
+  it('does not report unterminated errors for well-formed input', () => {
+    const doc = parse('/* fine */ struct Foo { FP x; } // "quoted"', 'test://clean.qtn');
+    expect(doc.parseErrors.some((e) => /unterminated/i.test(e.message))).toBe(false);
+  });
+});

--- a/language-server/src/__tests__/hover.test.ts
+++ b/language-server/src/__tests__/hover.test.ts
@@ -43,6 +43,18 @@ component P {
     expect(value).toContain('test.qtn');
   });
 
+  it('resolves a nullable user-defined type to its declaration site', () => {
+    const source = `struct Stats { }
+component P {
+  Stats? S;
+}`;
+    // Cursor on 'Stats' in the nullable field type.
+    const value = hoverText(source, 2, 4);
+    expect(value).not.toBeNull();
+    // Keeping the original name (not 'NullableStats') lets the lookup resolve.
+    expect(value).toContain('test.qtn');
+  });
+
   it('returns null when the cursor is not on an identifier', () => {
     // Leading blank line: offset 0 sits on a newline, no identifier to resolve.
     expect(hoverText('\ncomponent P {}', 0, 0)).toBeNull();

--- a/language-server/src/__tests__/hover.test.ts
+++ b/language-server/src/__tests__/hover.test.ts
@@ -43,6 +43,30 @@ component P {
     expect(value).toContain('test.qtn');
   });
 
+  it('describes a user-defined type prefixed with @', () => {
+    const source = `struct @Player {
+  int Hp;
+}
+component Game {
+  @Player Actor;
+}`;
+    const value = hoverText(source, 4, 4);
+    expect(value).not.toBeNull();
+    expect(value).toContain('test.qtn');
+  });
+
+  it('resolves a nullable user-defined type to its declaration site', () => {
+    const source = `struct Stats { }
+component P {
+  Stats? S;
+}`;
+    // Cursor on 'Stats' in the nullable field type.
+    const value = hoverText(source, 2, 4);
+    expect(value).not.toBeNull();
+    // Keeping the original name (not 'NullableStats') lets the lookup resolve.
+    expect(value).toContain('test.qtn');
+  });
+
   it('returns null when the cursor is not on an identifier', () => {
     // Leading blank line: offset 0 sits on a newline, no identifier to resolve.
     expect(hoverText('\ncomponent P {}', 0, 0)).toBeNull();

--- a/language-server/src/__tests__/incremental-symbol-table.test.ts
+++ b/language-server/src/__tests__/incremental-symbol-table.test.ts
@@ -1,0 +1,107 @@
+// Tests for incremental symbol-table updates.
+//
+// Updating one document must not drop symbols contributed by other documents,
+// builtins must persist across updates without being rebuilt from scratch, and
+// removing a document must drop only that document's symbols.
+
+import { describe, it, expect } from 'vitest';
+import { ProjectModel } from '../project-model.js';
+import { SymbolTable } from '../symbol-table.js';
+import { parse } from '../parser.js';
+
+describe('Incremental symbol table', () => {
+  it('updating one document keeps another document\'s symbols', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }');
+    pm.updateDocument('test://b.qtn', 'component Beta { FP B; }');
+
+    expect(pm.findDefinition('Alpha')).not.toBeNull();
+    expect(pm.findDefinition('Beta')).not.toBeNull();
+
+    // Re-edit only document A; B's symbol must survive.
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; Int32 Extra; }');
+
+    expect(pm.findDefinition('Alpha')).not.toBeNull();
+    expect(pm.findDefinition('Beta')).not.toBeNull();
+  });
+
+  it('builtins persist across document updates', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }');
+
+    const fpBefore = pm.getSymbolTable().lookup('FP');
+    expect(fpBefore?.source).toBe('builtin');
+
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; FP B; }');
+
+    const fpAfter = pm.getSymbolTable().lookup('FP');
+    expect(fpAfter?.source).toBe('builtin');
+  });
+
+  it('removeDocument drops only that document\'s symbols', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }');
+    pm.updateDocument('test://b.qtn', 'component Beta { FP B; }');
+
+    pm.removeDocument('test://a.qtn');
+
+    expect(pm.findDefinition('Alpha')).toBeNull();
+    expect(pm.findDefinition('Beta')).not.toBeNull();
+    // Builtins remain available after a removal.
+    expect(pm.getSymbolTable().lookup('FP')?.source).toBe('builtin');
+  });
+
+  it('removing a document that shadowed a builtin restores the builtin', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://shadow.qtn', 'struct FP { Int32 X; }');
+
+    expect(pm.getSymbolTable().lookup('FP')?.source).toBe('user');
+
+    pm.removeDocument('test://shadow.qtn');
+
+    expect(pm.getSymbolTable().lookup('FP')?.source).toBe('builtin');
+  });
+
+  it('keeps a later document\'s winner when an earlier document is re-edited', () => {
+    const pm = new ProjectModel();
+    // Both documents define Shared; the later-inserted b.qtn wins, matching the
+    // old full-rebuild insertion-order semantics.
+    pm.updateDocument('test://a.qtn', 'component Shared { FP A; }');
+    pm.updateDocument('test://b.qtn', 'struct Shared { Int32 B; }');
+
+    const winnerBefore = pm.getSymbolTable().lookup('Shared');
+    expect(winnerBefore?.location.uri).toBe('test://b.qtn');
+
+    // Re-edit a.qtn (still defines Shared, grows by a field). b.qtn must still win.
+    pm.updateDocument('test://a.qtn', 'component Shared { FP A; FP A2; }');
+
+    const winnerAfter = pm.getSymbolTable().lookup('Shared');
+    expect(winnerAfter?.location.uri).toBe('test://b.qtn');
+  });
+
+  it('drops a name when a re-edit removes its definition', () => {
+    const pm = new ProjectModel();
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }\ncomponent Gamma { FP G; }');
+    expect(pm.findDefinition('Gamma')).not.toBeNull();
+
+    pm.updateDocument('test://a.qtn', 'component Alpha { FP A; }');
+    expect(pm.findDefinition('Alpha')).not.toBeNull();
+    expect(pm.findDefinition('Gamma')).toBeNull();
+  });
+
+  it('SymbolTable.removeDocument removes a single document\'s contribution', () => {
+    const table = new SymbolTable();
+    table.mergeBuiltins();
+    table.addFromDocument(parse('component Alpha { FP A; }', 'test://a.qtn'));
+    table.addFromDocument(parse('#define FOO 1', 'test://b.qtn'));
+
+    expect(table.lookup('Alpha')).toBeDefined();
+    expect(table.lookup('FOO')).toBeDefined();
+
+    table.removeDocument('test://b.qtn');
+
+    expect(table.lookup('Alpha')).toBeDefined();
+    expect(table.lookup('FOO')).toBeUndefined();
+    expect(table.lookup('FP')?.source).toBe('builtin');
+  });
+});

--- a/language-server/src/__tests__/parser-edge-cases.test.ts
+++ b/language-server/src/__tests__/parser-edge-cases.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { parse } from '../parser.js';
+import { TypeDefinition } from '../ast.js';
 
 describe('Parser Edge Cases', () => {
   it('should handle empty files without errors', () => {
@@ -192,5 +193,24 @@ describe('Parser Edge Cases', () => {
 
     // Will have errors
     expect(result.parseErrors.length).toBeGreaterThan(0);
+  });
+
+  it('should record nullable suffix without mutating the type name', () => {
+    const result = parse('struct S { FP? Maybe; }', 'test://nullable.qtn');
+    const struct = result.definitions.find(d => d.kind === 'struct') as TypeDefinition;
+    const typeRef = struct.fields[0].typeRef;
+
+    // Name stays the source name (NOT 'NullableFP') so symbol lookups resolve.
+    expect(typeRef.name).toBe('FP');
+    expect(typeRef.isNullable).toBe(true);
+    // nameRange covers only 'FP', not the trailing '?'.
+    const nameLen = typeRef.nameRange.end.character - typeRef.nameRange.start.character;
+    expect(nameLen).toBe('FP'.length);
+  });
+
+  it('should leave isNullable false for non-nullable types', () => {
+    const result = parse('struct S { FP Value; }', 'test://non-nullable.qtn');
+    const struct = result.definitions.find(d => d.kind === 'struct') as TypeDefinition;
+    expect(struct.fields[0].typeRef.isNullable).toBe(false);
   });
 });

--- a/language-server/src/__tests__/semantic-tokens.test.ts
+++ b/language-server/src/__tests__/semantic-tokens.test.ts
@@ -200,6 +200,23 @@ event MyEvent {
     expect(tokens).toHaveLength(0);
   });
 
+  it('should emit a correctly-sized token for a nullable user-defined type', () => {
+    const source = `
+struct Health { }
+component Player {
+  Health? Maybe;
+}`;
+    const result = getTokens(source);
+    expect(result).not.toBeNull();
+
+    const tokens = decodeTokens(result!.data);
+    // The nullable 'Health?' field type resolves to the user-defined struct and
+    // the token must span exactly 'Health' (6 chars), not 'NullableHealth' (14).
+    const structTokens = tokens.filter(t => t.tokenType === tokenTypes.indexOf('struct'));
+    expect(structTokens.length).toBeGreaterThanOrEqual(1);
+    expect(structTokens.every(t => t.length === 'Health'.length)).toBe(true);
+  });
+
   it('should handle nameRange correctly for multiline token positions', () => {
     const source = `
 struct StateA { }

--- a/language-server/src/__tests__/user-visible-bugs.test.ts
+++ b/language-server/src/__tests__/user-visible-bugs.test.ts
@@ -110,4 +110,21 @@ signal OnBeforeDamage(FP damage, Resources* resources);
     expect(formatTypeReference(signal.parameters[1].typeRef)).toBe('Resources*');
     expect(buildSignalDetail(signal)).toBe('signal(FP, Resources*)');
   });
+
+  it('formats nullable field types using QTN suffix syntax', () => {
+    const result = parse(`
+struct Stats {}
+component Player {
+  Stats? MaybeStats;
+}`, 'test://nullable-format.qtn');
+
+    expect(result.parseErrors).toHaveLength(0);
+
+    const component = result.definitions.find((def) => def.kind === 'component');
+    if (component?.kind !== 'component') {
+      throw new Error('Expected component definition');
+    }
+
+    expect(formatTypeReference(component.fields[0].typeRef)).toBe('Stats?');
+  });
 });

--- a/language-server/src/ast.ts
+++ b/language-server/src/ast.ts
@@ -36,6 +36,7 @@ export interface TypeReference {
   genericArgs: TypeArgument[];
   arraySize?: number;  // fixed array size: array<T>[N]
   isPointer: boolean;  // signal parameter pointer: *
+  isNullable: boolean; // nullable suffix: Type?
   range: SourceRange;
 }
 

--- a/language-server/src/ast.ts
+++ b/language-server/src/ast.ts
@@ -36,6 +36,7 @@ export interface TypeReference {
   genericArgs: TypeArgument[];
   arraySize?: number;  // fixed array size: array<T>[N]
   isPointer: boolean;  // signal parameter pointer: *
+  isNullable: boolean; // nullable suffix: Type?
   range: SourceRange;
 }
 
@@ -152,7 +153,7 @@ export type Definition =
   | PragmaDefinition
   | DefineDefinition;
 
-// Parse error (internal, no diagnostics published)
+// Parse/lex error surfaced to the editor as an LSP diagnostic.
 export interface ParseError {
   message: string;
   range: SourceRange;

--- a/language-server/src/ast.ts
+++ b/language-server/src/ast.ts
@@ -152,7 +152,7 @@ export type Definition =
   | PragmaDefinition
   | DefineDefinition;
 
-// Parse error (internal, no diagnostics published)
+// Parse/lex error surfaced to the editor as an LSP diagnostic.
 export interface ParseError {
   message: string;
   range: SourceRange;

--- a/language-server/src/completion.ts
+++ b/language-server/src/completion.ts
@@ -23,6 +23,7 @@ import {
 } from './builtins.js';
 import { getLocale } from './locale.js';
 import { nodeKindToSymbolKind } from './symbol-table.js';
+import { scanBrackets } from './text-navigation.js';
 
 // Completion context types
 type CompletionContext =
@@ -128,57 +129,7 @@ function detectContext(
  * Check if there's an unmatched '[' (inside attribute)
  */
 function hasUnmatchedOpenBracket(text: string): boolean {
-  let openCount = 0;
-  let inString = false;
-  let inLineComment = false;
-  let inBlockComment = false;
-
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    const next = text[i + 1];
-
-    // Handle comments
-    if (!inString && !inBlockComment && ch === '/' && next === '/') {
-      inLineComment = true;
-      i++;
-      continue;
-    }
-    if (!inString && !inLineComment && ch === '/' && next === '*') {
-      inBlockComment = true;
-      i++;
-      continue;
-    }
-    if (inBlockComment && ch === '*' && next === '/') {
-      inBlockComment = false;
-      i++;
-      continue;
-    }
-    if (inLineComment && (ch === '\n' || ch === '\r')) {
-      inLineComment = false;
-      continue;
-    }
-
-    // Skip if in comment
-    if (inLineComment || inBlockComment) continue;
-
-    // Handle strings
-    if (ch === '"' && (i === 0 || text[i - 1] !== '\\')) {
-      inString = !inString;
-      continue;
-    }
-
-    // Skip if in string
-    if (inString) continue;
-
-    // Count brackets
-    if (ch === '[') {
-      openCount++;
-    } else if (ch === ']') {
-      openCount--;
-    }
-  }
-
-  return openCount > 0;
+  return scanBrackets(text).squareDepth > 0;
 }
 
 /**
@@ -264,30 +215,8 @@ function isInsideInputBlock(text: string, offset: number): boolean {
  * Check if in field type position (inside block, after '{' or ';')
  */
 function isFieldTypePosition(text: string, offset: number): boolean {
-  // Look for unmatched '{' without a closing '}'
-  let braceDepth = 0;
-  let inString = false;
-
-  for (let i = 0; i < offset; i++) {
-    const ch = text[i];
-
-    // Handle strings
-    if (ch === '"' && (i === 0 || text[i - 1] !== '\\')) {
-      inString = !inString;
-      continue;
-    }
-
-    if (inString) continue;
-
-    if (ch === '{') {
-      braceDepth++;
-    } else if (ch === '}') {
-      braceDepth--;
-    }
-  }
-
-  // We're in field type position if we're inside a block (braceDepth > 0)
-  return braceDepth > 0;
+  // We're in field type position when the cursor sits inside an open block.
+  return scanBrackets(text.substring(0, offset)).braceDepth > 0;
 }
 
 /**

--- a/language-server/src/diagnostics.ts
+++ b/language-server/src/diagnostics.ts
@@ -1,0 +1,25 @@
+// Converts QTN parse/lex errors into LSP diagnostics.
+// Kept pure (no LSP connection) so it can be unit-tested in isolation.
+
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { QtnDocument, ParseError } from './ast.js';
+
+export const DIAGNOSTIC_SOURCE = 'qtn';
+
+/** Convert a single parse error into an LSP diagnostic. */
+function toDiagnostic(error: ParseError): Diagnostic {
+  return {
+    severity: DiagnosticSeverity.Error,
+    range: error.range,
+    message: error.message,
+    source: DIAGNOSTIC_SOURCE,
+  };
+}
+
+/**
+ * Build the diagnostic list for a parsed document. Returns an empty array
+ * when there are no parse errors so callers can clear stale diagnostics.
+ */
+export function diagnosticsForDocument(doc: QtnDocument): Diagnostic[] {
+  return doc.parseErrors.map(toDiagnostic);
+}

--- a/language-server/src/lexer.ts
+++ b/language-server/src/lexer.ts
@@ -1,5 +1,5 @@
 // QTN Lexer - Token stream generator for QTN parser
-import { Position, SourceRange } from './ast.js';
+import { Position, SourceRange, ParseError } from './ast.js';
 
 // Token types
 export enum TokenType {
@@ -44,6 +44,7 @@ class Lexer {
   private line: number;
   private character: number;
   private tokens: QtnToken[];
+  private errors: ParseError[];
 
   constructor(text: string) {
     this.text = text;
@@ -51,6 +52,11 @@ class Lexer {
     this.line = 0;
     this.character = 0;
     this.tokens = [];
+    this.errors = [];
+  }
+
+  getErrors(): ParseError[] {
+    return this.errors;
   }
 
   // Get current character
@@ -119,6 +125,7 @@ class Lexer {
 
   // Skip multi-line comment: /* ... */
   private skipBlockComment(): void {
+    const start = this.currentPosition();
     // Skip /*
     this.advance();
     this.advance();
@@ -129,16 +136,23 @@ class Lexer {
       if (ch === '*' && this.peek() === '/') {
         this.advance(); // skip *
         this.advance(); // skip /
-        break;
+        return;
       }
       this.advance();
     }
+
+    // Reached EOF without a closing */
+    this.errors.push({
+      message: 'Unterminated block comment',
+      range: { start, end: this.currentPosition() },
+    });
   }
 
   // Read string literal: "..."
   private readString(): QtnToken {
     const start = this.currentPosition();
     let value = '';
+    let terminated = false;
 
     // Skip opening quote
     this.advance();
@@ -149,6 +163,7 @@ class Lexer {
       if (ch === '"') {
         // End of string
         this.advance();
+        terminated = true;
         break;
       } else if (ch === '\\') {
         // Escape sequence
@@ -179,6 +194,14 @@ class Lexer {
     }
 
     const end = this.currentPosition();
+
+    if (!terminated) {
+      this.errors.push({
+        message: 'Unterminated string literal',
+        range: { start, end },
+      });
+    }
+
     return {
       type: TokenType.string,
       value,
@@ -426,8 +449,21 @@ class Lexer {
   }
 }
 
+// Result of tokenizing with lexer-level diagnostics attached.
+export interface LexResult {
+  tokens: QtnToken[];
+  errors: ParseError[];
+}
+
 // Main entry point
 export function tokenize(text: string): QtnToken[] {
   const lexer = new Lexer(text);
   return lexer.tokenize();
+}
+
+// Tokenize and also surface lexer errors (unterminated strings/comments).
+export function tokenizeWithErrors(text: string): LexResult {
+  const lexer = new Lexer(text);
+  const tokens = lexer.tokenize();
+  return { tokens, errors: lexer.getErrors() };
 }

--- a/language-server/src/parser.ts
+++ b/language-server/src/parser.ts
@@ -1038,13 +1038,11 @@ class Parser {
       this.expect(TokenType.punctuation, ']');
     }
 
-    // Nullable suffix: FP? → becomes NullableFP conceptually, but
-    // we store it as the original name with `?` appended for downstream.
-    // Actually the AST TypeReference doesn't have an isNullable flag.
-    // The DSL maps FP? → NullableFP at codegen. For the parser we record
-    // it as the name with a nullable indicator. Let's just rename it.
+    // Nullable suffix: FP? — keep the original name so symbol lookups and
+    // nameRange stay accurate. The DSL maps it to NullableFP at codegen.
+    let isNullable = false;
     if (this.match(TokenType.punctuation, '?')) {
-      name = 'Nullable' + name;
+      isNullable = true;
     }
 
     // Pointer suffix: Type* (used in signal params)
@@ -1061,6 +1059,7 @@ class Parser {
       genericArgs,
       arraySize,
       isPointer,
+      isNullable,
       range: this.makeRange(startRange, endRange),
     };
   }

--- a/language-server/src/parser.ts
+++ b/language-server/src/parser.ts
@@ -2,7 +2,7 @@
 // Converts token stream from lexer into AST (ast.ts nodes).
 // Implements panic-mode error recovery: on parse errors, skips to }, ;, or top-level keyword.
 
-import { tokenize, QtnToken, TokenType } from './lexer.js';
+import { tokenizeWithErrors, QtnToken, TokenType } from './lexer.js';
 import {
   type SourceRange,
   type Position,
@@ -52,11 +52,13 @@ class Parser {
   private fileUri: string;
   private errors: ParseError[];
 
-  constructor(tokens: QtnToken[], fileUri: string) {
+  constructor(tokens: QtnToken[], fileUri: string, initialErrors: ParseError[] = []) {
     this.tokens = tokens;
     this.pos = 0;
     this.fileUri = fileUri;
-    this.errors = [];
+    // Lexer-level errors (unterminated strings/comments) are seeded first so
+    // they surface alongside parse errors in the resulting QtnDocument.
+    this.errors = [...initialErrors];
   }
 
   // ── Token helpers ──────────────────────────────────────────────
@@ -1038,13 +1040,11 @@ class Parser {
       this.expect(TokenType.punctuation, ']');
     }
 
-    // Nullable suffix: FP? → becomes NullableFP conceptually, but
-    // we store it as the original name with `?` appended for downstream.
-    // Actually the AST TypeReference doesn't have an isNullable flag.
-    // The DSL maps FP? → NullableFP at codegen. For the parser we record
-    // it as the name with a nullable indicator. Let's just rename it.
+    // Nullable suffix: FP? — keep the original name so symbol lookups and
+    // nameRange stay accurate. The DSL maps it to NullableFP at codegen.
+    let isNullable = false;
     if (this.match(TokenType.punctuation, '?')) {
-      name = 'Nullable' + name;
+      isNullable = true;
     }
 
     // Pointer suffix: Type* (used in signal params)
@@ -1061,6 +1061,7 @@ class Parser {
       genericArgs,
       arraySize,
       isPointer,
+      isNullable,
       range: this.makeRange(startRange, endRange),
     };
   }
@@ -1219,7 +1220,7 @@ class Parser {
 // ── Public API ─────────────────────────────────────────────────────
 
 export function parse(text: string, fileUri: string): QtnDocument {
-  const tokens = tokenize(text);
-  const parser = new Parser(tokens, fileUri);
+  const { tokens, errors } = tokenizeWithErrors(text);
+  const parser = new Parser(tokens, fileUri, errors);
   return parser.parse();
 }

--- a/language-server/src/parser.ts
+++ b/language-server/src/parser.ts
@@ -2,7 +2,7 @@
 // Converts token stream from lexer into AST (ast.ts nodes).
 // Implements panic-mode error recovery: on parse errors, skips to }, ;, or top-level keyword.
 
-import { tokenize, QtnToken, TokenType } from './lexer.js';
+import { tokenizeWithErrors, QtnToken, TokenType } from './lexer.js';
 import {
   type SourceRange,
   type Position,
@@ -52,11 +52,13 @@ class Parser {
   private fileUri: string;
   private errors: ParseError[];
 
-  constructor(tokens: QtnToken[], fileUri: string) {
+  constructor(tokens: QtnToken[], fileUri: string, initialErrors: ParseError[] = []) {
     this.tokens = tokens;
     this.pos = 0;
     this.fileUri = fileUri;
-    this.errors = [];
+    // Lexer-level errors (unterminated strings/comments) are seeded first so
+    // they surface alongside parse errors in the resulting QtnDocument.
+    this.errors = [...initialErrors];
   }
 
   // ── Token helpers ──────────────────────────────────────────────
@@ -1219,7 +1221,7 @@ class Parser {
 // ── Public API ─────────────────────────────────────────────────────
 
 export function parse(text: string, fileUri: string): QtnDocument {
-  const tokens = tokenize(text);
-  const parser = new Parser(tokens, fileUri);
+  const { tokens, errors } = tokenizeWithErrors(text);
+  const parser = new Parser(tokens, fileUri, errors);
   return parser.parse();
 }

--- a/language-server/src/project-model.ts
+++ b/language-server/src/project-model.ts
@@ -12,24 +12,24 @@ import { SymbolTable, SymbolInfo } from './symbol-table.js';
  * - A map of URI -> parsed QtnDocument
  * - A unified SymbolTable aggregating symbols from all documents
  *
- * When documents change, the symbol table is rebuilt from scratch to ensure consistency.
+ * Symbol-table updates are incremental: a changed document only re-indexes its
+ * own symbols, and builtins are computed once and reused. Removing a document
+ * drops only that document's symbols.
  */
 export class ProjectModel {
   private documents: Map<string, QtnDocument>;
   private symbolTable: SymbolTable;
-  private dirty: boolean;
 
   constructor() {
     this.documents = new Map();
     this.symbolTable = new SymbolTable();
-    this.dirty = false;
     // Pre-populate with built-in types
     this.symbolTable.mergeBuiltins();
   }
 
   /**
-   * Update a document: re-parse the text and mark symbol table as dirty.
-   * The symbol table will be lazily rebuilt on next access.
+   * Update a document: re-parse the text and re-index only this document's
+   * symbols into the shared symbol table.
    * @param uri - Document URI
    * @param text - Full document text
    */
@@ -54,19 +54,17 @@ export class ProjectModel {
     // Store in documents map
     this.documents.set(uri, doc);
 
-    // Mark symbol table as dirty for lazy rebuild
-    this.dirty = true;
+    // Re-index only this document; other documents and builtins are untouched.
+    this.symbolTable.addFromDocument(doc);
   }
 
   /**
-   * Remove a document from the project model.
+   * Remove a document from the project model along with its symbols.
    * @param uri - Document URI to remove
    */
   removeDocument(uri: string): void {
     this.documents.delete(uri);
-
-    // Mark symbol table as dirty for lazy rebuild
-    this.dirty = true;
+    this.symbolTable.removeDocument(uri);
   }
 
   /**
@@ -88,12 +86,9 @@ export class ProjectModel {
 
   /**
    * Get all symbols from the symbol table.
-   * Rebuilds the symbol table if it's marked as dirty.
    * @returns Array of all SymbolInfo objects
    */
   getAllSymbols(): SymbolInfo[] {
-    this.ensureSymbolTableFresh();
-
     const symbols: SymbolInfo[] = [];
 
     // Collect all type symbols
@@ -111,13 +106,10 @@ export class ProjectModel {
 
   /**
    * Find the definition location of a symbol by name.
-   * Rebuilds the symbol table if it's marked as dirty.
    * @param name - Symbol name to look up
    * @returns Location if found and user-defined, null otherwise
    */
   findDefinition(name: string): Location | null {
-    this.ensureSymbolTableFresh();
-
     const symbol = this.symbolTable.lookup(name);
 
     // Only return user-defined symbols (not builtins or imports)
@@ -130,39 +122,9 @@ export class ProjectModel {
 
   /**
    * Get the symbol table for direct access by handlers.
-   * Rebuilds the symbol table if it's marked as dirty.
    * @returns The SymbolTable instance
    */
   getSymbolTable(): SymbolTable {
-    this.ensureSymbolTableFresh();
     return this.symbolTable;
-  }
-
-  /**
-   * Ensure the symbol table is fresh, rebuilding if necessary.
-   * This is called by all methods that access the symbol table.
-   */
-  private ensureSymbolTableFresh(): void {
-    if (this.dirty) {
-      this.rebuildSymbolTable();
-      this.dirty = false;
-    }
-  }
-
-  /**
-   * Rebuild the symbol table from all documents.
-   * This creates a fresh symbol table, merges builtins, then adds symbols from each document.
-   */
-  private rebuildSymbolTable(): void {
-    // Create new symbol table
-    this.symbolTable = new SymbolTable();
-
-    // Pre-populate with built-ins
-    this.symbolTable.mergeBuiltins();
-
-    // Add symbols from each document
-    for (const doc of this.documents.values()) {
-      this.symbolTable.addFromDocument(doc);
-    }
   }
 }

--- a/language-server/src/semantic-tokens.ts
+++ b/language-server/src/semantic-tokens.ts
@@ -144,11 +144,18 @@ export function handleSemanticTokensFull(
 
       const tokenType = symbolKindToTokenType(symbol.kind);
 
-      // Use name.length for correct token length (handles multiline dotted names)
+      // Derive length from nameRange so it stays correct regardless of how the
+      // name was stored (e.g. nullable types). Fall back to name.length for
+      // multiline dotted names where columns span lines.
+      const { start, end } = typeRef.nameRange;
+      const length = start.line === end.line
+        ? end.character - start.character
+        : typeRef.name.length;
+
       tokens.push({
-        line: typeRef.nameRange.start.line,
-        char: typeRef.nameRange.start.character,
-        length: typeRef.name.length,
+        line: start.line,
+        char: start.character,
+        length,
         tokenType,
         tokenModifiers: 0,
       });

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -21,6 +21,7 @@ import { handleHover } from './hover.js';
 import { handleDocumentSymbol, handleWorkspaceSymbol } from './symbols.js';
 import { handleSemanticTokensFull, tokenTypes, tokenModifiers } from './semantic-tokens.js';
 import { setLocale } from './locale.js';
+import { diagnosticsForDocument } from './diagnostics.js';
 
 // Create LSP connection using Node IPC
 const connection = createConnection(ProposedFeatures.all);
@@ -84,12 +85,29 @@ connection.onInitialized(() => {
 // Document change handler - update project model when documents change
 documents.onDidChangeContent((change) => {
   projectModel.updateDocument(change.document.uri, change.document.getText());
+  publishDiagnostics(change.document.uri);
 });
 
 // Document close handler - keep workspace files indexed from disk.
 documents.onDidClose((event) => {
+  // The buffer is gone from the editor; clear its diagnostics. If the file
+  // still exists on disk, reloadClosedDocument re-publishes from disk content.
+  clearDiagnostics(event.document.uri);
   void reloadClosedDocument(event.document.uri);
 });
+
+// Publish syntax diagnostics for a parsed document. Sends an empty array to
+// clear when there are no errors. Safe to call only after the document has
+// been (re)parsed into the project model.
+function publishDiagnostics(uri: string): void {
+  const doc = projectModel.getDocument(uri);
+  const diagnostics = doc ? diagnosticsForDocument(doc) : [];
+  void connection.sendDiagnostics({ uri, diagnostics });
+}
+
+function clearDiagnostics(uri: string): void {
+  void connection.sendDiagnostics({ uri, diagnostics: [] });
+}
 
 // Handle workspace file changes (external edits, file creation/deletion)
 connection.onDidChangeWatchedFiles((params) => {
@@ -99,6 +117,7 @@ connection.onDidChangeWatchedFiles((params) => {
     switch (change.type) {
       case FileChangeType.Deleted:
         projectModel.removeDocument(change.uri);
+        clearDiagnostics(change.uri);
         break;
       case FileChangeType.Created:
       case FileChangeType.Changed:
@@ -158,6 +177,7 @@ async function loadFileIntoProject(uri: string): Promise<void> {
   const openDocument = documents.get(uri);
   if (openDocument) {
     projectModel.updateDocument(uri, openDocument.getText());
+    publishDiagnostics(uri);
     return;
   }
 
@@ -169,9 +189,11 @@ async function loadFileIntoProject(uri: string): Promise<void> {
   try {
     const text = await fs.readFile(filePath, 'utf8');
     projectModel.updateDocument(uri, text);
+    publishDiagnostics(uri);
   } catch (error) {
     if (isMissingFileError(error)) {
       projectModel.removeDocument(uri);
+      clearDiagnostics(uri);
       return;
     }
 

--- a/language-server/src/symbol-format.ts
+++ b/language-server/src/symbol-format.ts
@@ -20,6 +20,10 @@ export function formatTypeReference(typeRef: TypeReference): string {
     result += `[${typeRef.arraySize}]`;
   }
 
+  if (typeRef.isNullable) {
+    result += '?';
+  }
+
   if (typeRef.isPointer) {
     result += '*';
   }

--- a/language-server/src/symbol-table.ts
+++ b/language-server/src/symbol-table.ts
@@ -93,28 +93,223 @@ function createLocation(fileUri: string, sourceRange: SourceRange): Location {
   };
 }
 
+// Builtin symbols are identical for every SymbolTable instance and only vary by
+// locale (which affects descriptions). Build them once per locale and reuse the
+// cached array so a single document edit never rebuilds ~40 builtins from scratch.
+const builtinSymbolCache = new Map<string, SymbolInfo[]>();
+
+// What a single document contributed to the merged symbol table. Caching the
+// already-built SymbolInfo objects lets us re-derive the merged view on removal
+// without re-processing every other document's AST.
+interface DocumentContribution {
+  types: SymbolInfo[];
+  constants: SymbolInfo[];
+  imports: ImportDefinition[];
+}
+
+// Map a builtin's category to its LSP SymbolKind.
+function builtinSymbolKind(category: BuiltinTypeInfo['category']): SymbolKind {
+  switch (category) {
+    case 'primitive':
+      return SymbolKind.Struct;
+    case 'quantum':
+    case 'collection':
+    case 'special':
+    default:
+      return SymbolKind.Class;
+  }
+}
+
+function createBuiltinSymbol(builtin: BuiltinTypeInfo): SymbolInfo {
+  return {
+    name: builtin.name,
+    kind: builtinSymbolKind(builtin.category),
+    location: {
+      uri: 'builtin://',
+      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+    },
+    detail: getDescription(builtin, getLocale()),
+    children: [],
+    source: 'builtin',
+  };
+}
+
+// Builtin symbols for the active locale, computed once and memoized per locale.
+function getBuiltinSymbols(): SymbolInfo[] {
+  const locale = getLocale();
+  let symbols = builtinSymbolCache.get(locale);
+  if (!symbols) {
+    symbols = ALL_BUILTIN_TYPES.map(createBuiltinSymbol);
+    builtinSymbolCache.set(locale, symbols);
+  }
+  return symbols;
+}
+
 // Symbol Table class
 export class SymbolTable {
   types: Map<string, SymbolInfo> = new Map();
   constants: Map<string, SymbolInfo> = new Map();
   imports: ImportDefinition[] = [];
 
-  // Build symbol table from parsed QTN document
-  buildFromDocument(doc: QtnDocument): void {
-    this.types.clear();
-    this.constants.clear();
-    this.imports = [];
+  // Per-document contributions, in insertion order. Used to re-derive the merged
+  // maps incrementally when a single document is added, updated, or removed.
+  private contributions: Map<string, DocumentContribution> = new Map();
+  private builtinsMerged = false;
 
+  // Build symbol table from a single document, discarding any prior state.
+  buildFromDocument(doc: QtnDocument): void {
+    const hadBuiltins = this.builtinsMerged;
+    this.contributions.clear();
+    this.indexDocument(doc);
+    this.builtinsMerged = hadBuiltins;
+    this.rebuildMergedView();
+  }
+
+  // Add symbols from a document WITHOUT clearing existing symbols.
+  // Re-indexing the same uri replaces only that document's contribution; symbols
+  // from other documents and the builtins are left untouched.
+  addFromDocument(doc: QtnDocument): void {
+    const previous = this.contributions.get(doc.uri);
+    this.indexDocument(doc);
+    const next = this.contributions.get(doc.uri)!;
+
+    // Re-editing a document can drop names it used to define (un-shadowing a
+    // builtin or another document) or collide with another document's winner —
+    // those cases can't be resolved by a forward merge alone, so fall back to a
+    // re-derive. The re-derive only iterates cached SymbolInfo objects, never
+    // re-parses.
+    if (this.needsFullRederive(doc.uri, previous, next)) {
+      this.rebuildMergedView();
+      return;
+    }
+
+    // Common keystroke case: this document's names are a superset of before and
+    // don't collide with other documents, so applying its fresh symbols on top
+    // keeps last-write-wins correct without touching any other document.
+    // O(symbols in this one document).
+    this.applyContribution(next);
+  }
+
+  // Drop a single document's symbols. Because removal can un-shadow builtins or
+  // symbols from other documents, the merged maps are re-derived from the cached
+  // contributions rather than mutated in place.
+  removeDocument(uri: string): void {
+    if (!this.contributions.delete(uri)) {
+      return;
+    }
+    this.rebuildMergedView();
+  }
+
+  // A forward-only merge writes this document's fresh symbols straight into the
+  // live maps. That is only valid when it can't disturb another source's winner,
+  // so we fall back to a full re-derive (which still reuses cached SymbolInfo,
+  // never re-parses) in these cases:
+  //   - the re-edit removed a name it used to define (may un-shadow a builtin or
+  //     another document),
+  //   - the document declared imports (appended into a shared array; a clean
+  //     rebuild avoids leaving stale entries),
+  //   - one of the document's names is currently owned by a *different* document
+  //     (forward-merging would override that document's winner and break the
+  //     insertion-order last-write-wins rule).
+  private needsFullRederive(
+    uri: string,
+    previous: DocumentContribution | undefined,
+    next: DocumentContribution,
+  ): boolean {
+    if (previous?.imports.length || next.imports.length) {
+      return true;
+    }
+
+    if (previous) {
+      const nextTypeNames = new Set(next.types.map((s) => s.name));
+      for (const symbol of previous.types) {
+        if (!nextTypeNames.has(symbol.name)) {
+          return true;
+        }
+      }
+      const nextConstNames = new Set(next.constants.map((s) => s.name));
+      for (const symbol of previous.constants) {
+        if (!nextConstNames.has(symbol.name)) {
+          return true;
+        }
+      }
+    }
+
+    for (const symbol of next.types) {
+      if (this.ownedByOtherDocument(this.types.get(symbol.name), uri)) {
+        return true;
+      }
+    }
+    for (const symbol of next.constants) {
+      if (this.ownedByOtherDocument(this.constants.get(symbol.name), uri)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // True when the current winner for a name belongs to a different document, so a
+  // forward merge must not clobber it. Builtins (and an absent winner) are safe to
+  // overwrite by a user/import symbol, matching last-write-wins.
+  private ownedByOtherDocument(current: SymbolInfo | undefined, uri: string | undefined): boolean {
+    if (!current || current.source === 'builtin') {
+      return false;
+    }
+    return current.location.uri !== uri;
+  }
+
+  // Process the document's definitions into cached SymbolInfo objects, replacing
+  // any prior contribution for the same uri.
+  private indexDocument(doc: QtnDocument): void {
+    this.current = { types: [], constants: [], imports: [] };
     for (const def of doc.definitions) {
       this.processDefinition(def, doc.uri);
     }
+    this.contributions.set(doc.uri, this.current);
+    this.current = null;
   }
 
-  // Add symbols from a document WITHOUT clearing existing symbols
-  // Used by ProjectModel to incrementally build symbol table from multiple documents
-  addFromDocument(doc: QtnDocument): void {
-    for (const def of doc.definitions) {
-      this.processDefinition(def, doc.uri);
+  // Active contribution being populated by processDefinition during indexDocument.
+  private current: DocumentContribution | null = null;
+
+  // Re-derive the merged maps from builtins + all cached contributions, in
+  // insertion order so user definitions win over builtins and later documents
+  // win over earlier ones — exactly matching the previous full rebuild. Cheap
+  // because it reuses already-built SymbolInfo objects and cached builtins.
+  private rebuildMergedView(): void {
+    this.types = new Map();
+    this.constants = new Map();
+    this.imports = [];
+
+    if (this.builtinsMerged) {
+      for (const symbol of getBuiltinSymbols()) {
+        this.types.set(symbol.name, symbol);
+      }
+    }
+
+    for (const contribution of this.contributions.values()) {
+      this.applyContribution(contribution);
+    }
+  }
+
+  private applyContribution(contribution: DocumentContribution): void {
+    for (const symbol of contribution.types) {
+      // Imports never override an already-resolved non-import symbol (builtin,
+      // user, or import from another document) — same rule as the old inline
+      // processImportDefinition check.
+      if (symbol.source === 'import') {
+        const existing = this.types.get(symbol.name);
+        if (existing && existing.source !== 'import') {
+          continue;
+        }
+      }
+      this.types.set(symbol.name, symbol);
+    }
+    for (const symbol of contribution.constants) {
+      this.constants.set(symbol.name, symbol);
+    }
+    for (const imp of contribution.imports) {
+      this.imports.push(imp);
     }
   }
 
@@ -142,11 +337,11 @@ export class SymbolTable {
         this.processGlobalDefinition(def as GlobalDefinition, fileUri);
         break;
       case 'import':
-        this.imports.push(def as ImportDefinition);
+        this.emitImport(def as ImportDefinition);
         this.processImportDefinition(def as ImportDefinition, fileUri);
         break;
       case 'using':
-        this.imports.push(def as ImportDefinition);
+        this.emitImport(def as ImportDefinition);
         break;
       case 'define':
         this.processDefineDefinition(def as DefineDefinition, fileUri);
@@ -157,12 +352,9 @@ export class SymbolTable {
     }
   }
 
+  // Emit an import symbol into the current contribution. The decision to skip it
+  // when a non-import symbol already wins is applied later in applyContribution.
   private processImportDefinition(def: ImportDefinition, fileUri: string): void {
-    const existing = this.types.get(def.name);
-    if (existing && existing.source !== 'import') {
-      return;
-    }
-
     const symbol: SymbolInfo = {
       name: def.name,
       kind: this.importKindToSymbolKind(def.importKind),
@@ -172,7 +364,20 @@ export class SymbolTable {
       source: 'import',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
+  }
+
+  // Collect emitted symbols into the contribution being indexed.
+  private emitType(symbol: SymbolInfo): void {
+    this.current?.types.push(symbol);
+  }
+
+  private emitConstant(symbol: SymbolInfo): void {
+    this.current?.constants.push(symbol);
+  }
+
+  private emitImport(def: ImportDefinition): void {
+    this.current?.imports.push(def);
   }
 
   private importKindToSymbolKind(kind: ImportDefinition['importKind']): SymbolKind {
@@ -228,7 +433,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process event definition
@@ -252,7 +457,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process signal definition
@@ -268,7 +473,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process input definition
@@ -290,7 +495,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set('input', symbol);
+    this.emitType(symbol);
   }
 
   // Process global definition
@@ -312,7 +517,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set('global', symbol);
+    this.emitType(symbol);
   }
 
   // Process #define constant
@@ -326,7 +531,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.constants.set(def.name, symbol);
+    this.emitConstant(symbol);
   }
 
   // Create field symbol
@@ -355,48 +560,16 @@ export class SymbolTable {
     };
   }
 
-  // Pre-populate symbol table with built-in types
+  // Pre-populate symbol table with built-in types. Reuses the per-locale cached
+  // builtin symbols instead of recreating them on every call.
   mergeBuiltins(): void {
-    for (const builtin of ALL_BUILTIN_TYPES) {
-      const symbol = this.createBuiltinSymbol(builtin);
+    this.builtinsMerged = true;
+    for (const symbol of getBuiltinSymbols()) {
       // Don't overwrite user-defined types
       if (!this.types.has(symbol.name)) {
         this.types.set(symbol.name, symbol);
       }
     }
-  }
-
-  // Create symbol from builtin type info
-  private createBuiltinSymbol(builtin: BuiltinTypeInfo): SymbolInfo {
-    let kind: SymbolKind;
-    switch (builtin.category) {
-      case 'primitive':
-        kind = SymbolKind.Struct;
-        break;
-      case 'quantum':
-        kind = SymbolKind.Class;
-        break;
-      case 'collection':
-        kind = SymbolKind.Class;
-        break;
-      case 'special':
-        kind = SymbolKind.Class;
-        break;
-      default:
-        kind = SymbolKind.Class;
-    }
-
-    return {
-      name: builtin.name,
-      kind,
-      location: {
-        uri: 'builtin://',
-        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-      },
-      detail: getDescription(builtin, getLocale()),
-      children: [],
-      source: 'builtin',
-    };
   }
 
   // Lookup symbol by exact name

--- a/language-server/src/symbol-table.ts
+++ b/language-server/src/symbol-table.ts
@@ -404,46 +404,37 @@ export class SymbolTable {
     return this.types.get(name) || this.constants.get(name);
   }
 
+  // Score each entry in `map` against `lowerQuery` and append hits to `results`.
+  private scoreSymbols(
+    lowerQuery: string,
+    map: Map<string, SymbolInfo>,
+    results: Array<{ symbol: SymbolInfo; score: number }>
+  ): void {
+    for (const [name, symbol] of map) {
+      const lowerName = name.toLowerCase();
+      let score = 0;
+
+      if (lowerName === lowerQuery) {
+        score = 3; // Exact match
+      } else if (lowerName.startsWith(lowerQuery)) {
+        score = 2; // Prefix match
+      } else if (lowerName.includes(lowerQuery)) {
+        score = 1; // Contains match
+      }
+
+      if (score > 0) {
+        results.push({ symbol, score });
+      }
+    }
+  }
+
   // Fuzzy search for symbols (case-insensitive substring matching)
   fuzzySearch(query: string): SymbolInfo[] {
     const lowerQuery = query.toLowerCase();
     const results: Array<{ symbol: SymbolInfo; score: number }> = [];
 
-    // Search in types
-    for (const [name, symbol] of this.types) {
-      const lowerName = name.toLowerCase();
-      let score = 0;
-
-      if (lowerName === lowerQuery) {
-        score = 3; // Exact match
-      } else if (lowerName.startsWith(lowerQuery)) {
-        score = 2; // Prefix match
-      } else if (lowerName.includes(lowerQuery)) {
-        score = 1; // Contains match
-      }
-
-      if (score > 0) {
-        results.push({ symbol, score });
-      }
-    }
-
-    // Search in constants
-    for (const [name, symbol] of this.constants) {
-      const lowerName = name.toLowerCase();
-      let score = 0;
-
-      if (lowerName === lowerQuery) {
-        score = 3; // Exact match
-      } else if (lowerName.startsWith(lowerQuery)) {
-        score = 2; // Prefix match
-      } else if (lowerName.includes(lowerQuery)) {
-        score = 1; // Contains match
-      }
-
-      if (score > 0) {
-        results.push({ symbol, score });
-      }
-    }
+    this.scoreSymbols(lowerQuery, this.types, results);
+    this.scoreSymbols(lowerQuery, this.constants, results);
 
     // Sort by score (descending), then by name (ascending)
     results.sort((a, b) => {

--- a/language-server/src/symbol-table.ts
+++ b/language-server/src/symbol-table.ts
@@ -93,28 +93,223 @@ function createLocation(fileUri: string, sourceRange: SourceRange): Location {
   };
 }
 
+// Builtin symbols are identical for every SymbolTable instance and only vary by
+// locale (which affects descriptions). Build them once per locale and reuse the
+// cached array so a single document edit never rebuilds ~40 builtins from scratch.
+const builtinSymbolCache = new Map<string, SymbolInfo[]>();
+
+// What a single document contributed to the merged symbol table. Caching the
+// already-built SymbolInfo objects lets us re-derive the merged view on removal
+// without re-processing every other document's AST.
+interface DocumentContribution {
+  types: SymbolInfo[];
+  constants: SymbolInfo[];
+  imports: ImportDefinition[];
+}
+
+// Map a builtin's category to its LSP SymbolKind.
+function builtinSymbolKind(category: BuiltinTypeInfo['category']): SymbolKind {
+  switch (category) {
+    case 'primitive':
+      return SymbolKind.Struct;
+    case 'quantum':
+    case 'collection':
+    case 'special':
+    default:
+      return SymbolKind.Class;
+  }
+}
+
+function createBuiltinSymbol(builtin: BuiltinTypeInfo): SymbolInfo {
+  return {
+    name: builtin.name,
+    kind: builtinSymbolKind(builtin.category),
+    location: {
+      uri: 'builtin://',
+      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+    },
+    detail: getDescription(builtin, getLocale()),
+    children: [],
+    source: 'builtin',
+  };
+}
+
+// Builtin symbols for the active locale, computed once and memoized per locale.
+function getBuiltinSymbols(): SymbolInfo[] {
+  const locale = getLocale();
+  let symbols = builtinSymbolCache.get(locale);
+  if (!symbols) {
+    symbols = ALL_BUILTIN_TYPES.map(createBuiltinSymbol);
+    builtinSymbolCache.set(locale, symbols);
+  }
+  return symbols;
+}
+
 // Symbol Table class
 export class SymbolTable {
   types: Map<string, SymbolInfo> = new Map();
   constants: Map<string, SymbolInfo> = new Map();
   imports: ImportDefinition[] = [];
 
-  // Build symbol table from parsed QTN document
-  buildFromDocument(doc: QtnDocument): void {
-    this.types.clear();
-    this.constants.clear();
-    this.imports = [];
+  // Per-document contributions, in insertion order. Used to re-derive the merged
+  // maps incrementally when a single document is added, updated, or removed.
+  private contributions: Map<string, DocumentContribution> = new Map();
+  private builtinsMerged = false;
 
+  // Build symbol table from a single document, discarding any prior state.
+  buildFromDocument(doc: QtnDocument): void {
+    const hadBuiltins = this.builtinsMerged;
+    this.contributions.clear();
+    this.indexDocument(doc);
+    this.builtinsMerged = hadBuiltins;
+    this.rebuildMergedView();
+  }
+
+  // Add symbols from a document WITHOUT clearing existing symbols.
+  // Re-indexing the same uri replaces only that document's contribution; symbols
+  // from other documents and the builtins are left untouched.
+  addFromDocument(doc: QtnDocument): void {
+    const previous = this.contributions.get(doc.uri);
+    this.indexDocument(doc);
+    const next = this.contributions.get(doc.uri)!;
+
+    // Re-editing a document can drop names it used to define (un-shadowing a
+    // builtin or another document) or collide with another document's winner —
+    // those cases can't be resolved by a forward merge alone, so fall back to a
+    // re-derive. The re-derive only iterates cached SymbolInfo objects, never
+    // re-parses.
+    if (this.needsFullRederive(doc.uri, previous, next)) {
+      this.rebuildMergedView();
+      return;
+    }
+
+    // Common keystroke case: this document's names are a superset of before and
+    // don't collide with other documents, so applying its fresh symbols on top
+    // keeps last-write-wins correct without touching any other document.
+    // O(symbols in this one document).
+    this.applyContribution(next);
+  }
+
+  // Drop a single document's symbols. Because removal can un-shadow builtins or
+  // symbols from other documents, the merged maps are re-derived from the cached
+  // contributions rather than mutated in place.
+  removeDocument(uri: string): void {
+    if (!this.contributions.delete(uri)) {
+      return;
+    }
+    this.rebuildMergedView();
+  }
+
+  // A forward-only merge writes this document's fresh symbols straight into the
+  // live maps. That is only valid when it can't disturb another source's winner,
+  // so we fall back to a full re-derive (which still reuses cached SymbolInfo,
+  // never re-parses) in these cases:
+  //   - the re-edit removed a name it used to define (may un-shadow a builtin or
+  //     another document),
+  //   - the document declared imports (appended into a shared array; a clean
+  //     rebuild avoids leaving stale entries),
+  //   - one of the document's names is currently owned by a *different* document
+  //     (forward-merging would override that document's winner and break the
+  //     insertion-order last-write-wins rule).
+  private needsFullRederive(
+    uri: string,
+    previous: DocumentContribution | undefined,
+    next: DocumentContribution,
+  ): boolean {
+    if (previous?.imports.length || next.imports.length) {
+      return true;
+    }
+
+    if (previous) {
+      const nextTypeNames = new Set(next.types.map((s) => s.name));
+      for (const symbol of previous.types) {
+        if (!nextTypeNames.has(symbol.name)) {
+          return true;
+        }
+      }
+      const nextConstNames = new Set(next.constants.map((s) => s.name));
+      for (const symbol of previous.constants) {
+        if (!nextConstNames.has(symbol.name)) {
+          return true;
+        }
+      }
+    }
+
+    for (const symbol of next.types) {
+      if (this.ownedByOtherDocument(this.types.get(symbol.name), uri)) {
+        return true;
+      }
+    }
+    for (const symbol of next.constants) {
+      if (this.ownedByOtherDocument(this.constants.get(symbol.name), uri)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // True when the current winner for a name belongs to a different document, so a
+  // forward merge must not clobber it. Builtins (and an absent winner) are safe to
+  // overwrite by a user/import symbol, matching last-write-wins.
+  private ownedByOtherDocument(current: SymbolInfo | undefined, uri: string | undefined): boolean {
+    if (!current || current.source === 'builtin') {
+      return false;
+    }
+    return current.location.uri !== uri;
+  }
+
+  // Process the document's definitions into cached SymbolInfo objects, replacing
+  // any prior contribution for the same uri.
+  private indexDocument(doc: QtnDocument): void {
+    this.current = { types: [], constants: [], imports: [] };
     for (const def of doc.definitions) {
       this.processDefinition(def, doc.uri);
     }
+    this.contributions.set(doc.uri, this.current);
+    this.current = null;
   }
 
-  // Add symbols from a document WITHOUT clearing existing symbols
-  // Used by ProjectModel to incrementally build symbol table from multiple documents
-  addFromDocument(doc: QtnDocument): void {
-    for (const def of doc.definitions) {
-      this.processDefinition(def, doc.uri);
+  // Active contribution being populated by processDefinition during indexDocument.
+  private current: DocumentContribution | null = null;
+
+  // Re-derive the merged maps from builtins + all cached contributions, in
+  // insertion order so user definitions win over builtins and later documents
+  // win over earlier ones — exactly matching the previous full rebuild. Cheap
+  // because it reuses already-built SymbolInfo objects and cached builtins.
+  private rebuildMergedView(): void {
+    this.types = new Map();
+    this.constants = new Map();
+    this.imports = [];
+
+    if (this.builtinsMerged) {
+      for (const symbol of getBuiltinSymbols()) {
+        this.types.set(symbol.name, symbol);
+      }
+    }
+
+    for (const contribution of this.contributions.values()) {
+      this.applyContribution(contribution);
+    }
+  }
+
+  private applyContribution(contribution: DocumentContribution): void {
+    for (const symbol of contribution.types) {
+      // Imports never override an already-resolved non-import symbol (builtin,
+      // user, or import from another document) — same rule as the old inline
+      // processImportDefinition check.
+      if (symbol.source === 'import') {
+        const existing = this.types.get(symbol.name);
+        if (existing && existing.source !== 'import') {
+          continue;
+        }
+      }
+      this.types.set(symbol.name, symbol);
+    }
+    for (const symbol of contribution.constants) {
+      this.constants.set(symbol.name, symbol);
+    }
+    for (const imp of contribution.imports) {
+      this.imports.push(imp);
     }
   }
 
@@ -142,11 +337,11 @@ export class SymbolTable {
         this.processGlobalDefinition(def as GlobalDefinition, fileUri);
         break;
       case 'import':
-        this.imports.push(def as ImportDefinition);
+        this.emitImport(def as ImportDefinition);
         this.processImportDefinition(def as ImportDefinition, fileUri);
         break;
       case 'using':
-        this.imports.push(def as ImportDefinition);
+        this.emitImport(def as ImportDefinition);
         break;
       case 'define':
         this.processDefineDefinition(def as DefineDefinition, fileUri);
@@ -157,12 +352,9 @@ export class SymbolTable {
     }
   }
 
+  // Emit an import symbol into the current contribution. The decision to skip it
+  // when a non-import symbol already wins is applied later in applyContribution.
   private processImportDefinition(def: ImportDefinition, fileUri: string): void {
-    const existing = this.types.get(def.name);
-    if (existing && existing.source !== 'import') {
-      return;
-    }
-
     const symbol: SymbolInfo = {
       name: def.name,
       kind: this.importKindToSymbolKind(def.importKind),
@@ -172,7 +364,20 @@ export class SymbolTable {
       source: 'import',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
+  }
+
+  // Collect emitted symbols into the contribution being indexed.
+  private emitType(symbol: SymbolInfo): void {
+    this.current?.types.push(symbol);
+  }
+
+  private emitConstant(symbol: SymbolInfo): void {
+    this.current?.constants.push(symbol);
+  }
+
+  private emitImport(def: ImportDefinition): void {
+    this.current?.imports.push(def);
   }
 
   private importKindToSymbolKind(kind: ImportDefinition['importKind']): SymbolKind {
@@ -228,7 +433,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process event definition
@@ -252,7 +457,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process signal definition
@@ -268,7 +473,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set(def.name, symbol);
+    this.emitType(symbol);
   }
 
   // Process input definition
@@ -290,7 +495,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set('input', symbol);
+    this.emitType(symbol);
   }
 
   // Process global definition
@@ -312,7 +517,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.types.set('global', symbol);
+    this.emitType(symbol);
   }
 
   // Process #define constant
@@ -326,7 +531,7 @@ export class SymbolTable {
       source: 'user',
     };
 
-    this.constants.set(def.name, symbol);
+    this.emitConstant(symbol);
   }
 
   // Create field symbol
@@ -355,10 +560,11 @@ export class SymbolTable {
     };
   }
 
-  // Pre-populate symbol table with built-in types
+  // Pre-populate symbol table with built-in types. Reuses the per-locale cached
+  // builtin symbols instead of recreating them on every call.
   mergeBuiltins(): void {
-    for (const builtin of ALL_BUILTIN_TYPES) {
-      const symbol = this.createBuiltinSymbol(builtin);
+    this.builtinsMerged = true;
+    for (const symbol of getBuiltinSymbols()) {
       // Don't overwrite user-defined types
       if (!this.types.has(symbol.name)) {
         this.types.set(symbol.name, symbol);
@@ -366,42 +572,33 @@ export class SymbolTable {
     }
   }
 
-  // Create symbol from builtin type info
-  private createBuiltinSymbol(builtin: BuiltinTypeInfo): SymbolInfo {
-    let kind: SymbolKind;
-    switch (builtin.category) {
-      case 'primitive':
-        kind = SymbolKind.Struct;
-        break;
-      case 'quantum':
-        kind = SymbolKind.Class;
-        break;
-      case 'collection':
-        kind = SymbolKind.Class;
-        break;
-      case 'special':
-        kind = SymbolKind.Class;
-        break;
-      default:
-        kind = SymbolKind.Class;
-    }
-
-    return {
-      name: builtin.name,
-      kind,
-      location: {
-        uri: 'builtin://',
-        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-      },
-      detail: getDescription(builtin, getLocale()),
-      children: [],
-      source: 'builtin',
-    };
-  }
-
   // Lookup symbol by exact name
   lookup(name: string): SymbolInfo | undefined {
     return this.types.get(name) || this.constants.get(name);
+  }
+
+  // Score each entry in `map` against `lowerQuery` and append hits to `results`.
+  private scoreSymbols(
+    lowerQuery: string,
+    map: Map<string, SymbolInfo>,
+    results: Array<{ symbol: SymbolInfo; score: number }>
+  ): void {
+    for (const [name, symbol] of map) {
+      const lowerName = name.toLowerCase();
+      let score = 0;
+
+      if (lowerName === lowerQuery) {
+        score = 3; // Exact match
+      } else if (lowerName.startsWith(lowerQuery)) {
+        score = 2; // Prefix match
+      } else if (lowerName.includes(lowerQuery)) {
+        score = 1; // Contains match
+      }
+
+      if (score > 0) {
+        results.push({ symbol, score });
+      }
+    }
   }
 
   // Fuzzy search for symbols (case-insensitive substring matching)
@@ -409,41 +606,8 @@ export class SymbolTable {
     const lowerQuery = query.toLowerCase();
     const results: Array<{ symbol: SymbolInfo; score: number }> = [];
 
-    // Search in types
-    for (const [name, symbol] of this.types) {
-      const lowerName = name.toLowerCase();
-      let score = 0;
-
-      if (lowerName === lowerQuery) {
-        score = 3; // Exact match
-      } else if (lowerName.startsWith(lowerQuery)) {
-        score = 2; // Prefix match
-      } else if (lowerName.includes(lowerQuery)) {
-        score = 1; // Contains match
-      }
-
-      if (score > 0) {
-        results.push({ symbol, score });
-      }
-    }
-
-    // Search in constants
-    for (const [name, symbol] of this.constants) {
-      const lowerName = name.toLowerCase();
-      let score = 0;
-
-      if (lowerName === lowerQuery) {
-        score = 3; // Exact match
-      } else if (lowerName.startsWith(lowerQuery)) {
-        score = 2; // Prefix match
-      } else if (lowerName.includes(lowerQuery)) {
-        score = 1; // Contains match
-      }
-
-      if (score > 0) {
-        results.push({ symbol, score });
-      }
-    }
+    this.scoreSymbols(lowerQuery, this.types, results);
+    this.scoreSymbols(lowerQuery, this.constants, results);
 
     // Sort by score (descending), then by name (ascending)
     results.sort((a, b) => {

--- a/language-server/src/text-navigation.ts
+++ b/language-server/src/text-navigation.ts
@@ -37,3 +37,79 @@ export function getIdentifierAtPosition(
 export function isIdentifierChar(ch: string): boolean {
   return /[a-zA-Z0-9_]/.test(ch);
 }
+
+export interface BracketScan {
+  /** Net nesting depth of '[' minus ']' outside strings/comments. */
+  squareDepth: number;
+  /** Net nesting depth of '{' minus '}' outside strings/comments. */
+  braceDepth: number;
+}
+
+/**
+ * Single-pass scan that tracks line/block comments and string literals, then
+ * reports the net nesting depth of square brackets and curly braces in code.
+ *
+ * String parsing counts the run of consecutive backslashes before a quote: an
+ * odd run means the quote is escaped (e.g. `"...\""`), an even run (including
+ * zero) means it is a real delimiter. A naive "previous char isn't a backslash"
+ * check mis-reads a literal that ends in an escaped backslash like `"a\\"`.
+ */
+export function scanBrackets(text: string): BracketScan {
+  let squareDepth = 0;
+  let braceDepth = 0;
+  let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (!inString && !inBlockComment && ch === '/' && next === '/') {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (!inString && !inLineComment && ch === '/' && next === '*') {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (inBlockComment && ch === '*' && next === '/') {
+      inBlockComment = false;
+      i++;
+      continue;
+    }
+    if (inLineComment && (ch === '\n' || ch === '\r')) {
+      inLineComment = false;
+      continue;
+    }
+
+    if (inLineComment || inBlockComment) continue;
+
+    if (ch === '"') {
+      let backslashes = 0;
+      for (let j = i - 1; j >= 0 && text[j] === '\\'; j--) {
+        backslashes++;
+      }
+      if (backslashes % 2 === 0) {
+        inString = !inString;
+      }
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (ch === '[') {
+      squareDepth++;
+    } else if (ch === ']') {
+      squareDepth--;
+    } else if (ch === '{') {
+      braceDepth++;
+    } else if (ch === '}') {
+      braceDepth--;
+    }
+  }
+
+  return { squareDepth, braceDepth };
+}

--- a/language-server/src/text-navigation.ts
+++ b/language-server/src/text-navigation.ts
@@ -35,5 +35,81 @@ export function getIdentifierAtPosition(
 }
 
 export function isIdentifierChar(ch: string): boolean {
-  return /[a-zA-Z0-9_]/.test(ch);
+  return /[a-zA-Z0-9_@]/.test(ch);
+}
+
+export interface BracketScan {
+  /** Net nesting depth of '[' minus ']' outside strings/comments. */
+  squareDepth: number;
+  /** Net nesting depth of '{' minus '}' outside strings/comments. */
+  braceDepth: number;
+}
+
+/**
+ * Single-pass scan that tracks line/block comments and string literals, then
+ * reports the net nesting depth of square brackets and curly braces in code.
+ *
+ * String parsing counts the run of consecutive backslashes before a quote: an
+ * odd run means the quote is escaped (e.g. `"...\""`), an even run (including
+ * zero) means it is a real delimiter. A naive "previous char isn't a backslash"
+ * check mis-reads a literal that ends in an escaped backslash like `"a\\"`.
+ */
+export function scanBrackets(text: string): BracketScan {
+  let squareDepth = 0;
+  let braceDepth = 0;
+  let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (!inString && !inBlockComment && ch === '/' && next === '/') {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (!inString && !inLineComment && ch === '/' && next === '*') {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (inBlockComment && ch === '*' && next === '/') {
+      inBlockComment = false;
+      i++;
+      continue;
+    }
+    if (inLineComment && (ch === '\n' || ch === '\r')) {
+      inLineComment = false;
+      continue;
+    }
+
+    if (inLineComment || inBlockComment) continue;
+
+    if (ch === '"') {
+      let backslashes = 0;
+      for (let j = i - 1; j >= 0 && text[j] === '\\'; j--) {
+        backslashes++;
+      }
+      if (backslashes % 2 === 0) {
+        inString = !inString;
+      }
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (ch === '[') {
+      squareDepth++;
+    } else if (ch === ']') {
+      squareDepth--;
+    } else if (ch === '{') {
+      braceDepth++;
+    } else if (ch === '}') {
+      braceDepth--;
+    }
+  }
+
+  return { squareDepth, braceDepth };
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { workspace, ExtensionContext, env } from 'vscode';
+import { workspace, ExtensionContext, env, window } from 'vscode';
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -9,7 +9,7 @@ import {
 
 let client: LanguageClient | undefined;
 
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
   // Path to the language server module (bundled)
   const serverModule = path.join(
     context.extensionPath,
@@ -42,7 +42,14 @@ export function activate(context: ExtensionContext) {
     clientOptions
   );
 
-  client.start();
+  try {
+    await client.start();
+  } catch (err) {
+    console.error('QTN language server failed to start:', err);
+    void window.showErrorMessage(
+      `QTN Language Server failed to start: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
## Summary
- Integrates the useful open PR work for diagnostics, completion scanning, nullable type references, incremental symbol-table updates, fuzzy-search cleanup, @-identifier lookup, and VSCode language-client startup errors.
- Keeps the original intent of the useful PRs while fixing two gaps found during review: nullable type formatting now preserves `Type?`, and @-prefixed identifiers are handled in the current shared text-navigation path.
- Leaves existing individual PRs untouched so they can be closed or superseded manually after review.

## Included PRs / fixes
- #5 incremental symbol-table updates
- #6 nullable type reference lookup, with added `Type?` formatting preservation
- #7 syntax diagnostics and unterminated literal/comment errors
- #8 VSCode client startup error handling
- #9 escape-aware bracket scanner for completion context
- #10 fuzzySearch deduplication
- #3 core @-identifier fix reapplied against current code structure

## Verification
- `npm run compile`
- `npm --prefix language-server test` → 68 passed
- `npm --prefix language-server run test:integration` → 8 passed
- `npm run webpack` → passed with existing dynamic require warning from vscode-languageserver-types