### PR TITLE
fix: support component import declarations

### DIFF
--- a/language-server/src/__tests__/completion.test.ts
+++ b/language-server/src/__tests__/completion.test.ts
@@ -44,6 +44,7 @@ component Player {
   it('import context offers import sub-keywords', () => {
     const labels = complete('import Weapon', 0, 'import Weapon'.length);
     expect(labels).toEqual(expect.arrayContaining(IMPORT_SUB_KEYWORDS));
+    expect(labels).toContain('component');
   });
 
   it('enum-base context offers integer base types', () => {

--- a/language-server/src/__tests__/user-visible-bugs.test.ts
+++ b/language-server/src/__tests__/user-visible-bugs.test.ts
@@ -65,6 +65,20 @@ component UsesImports {
     expect(bar?.kind).toBe(SymbolKind.Enum);
   });
 
+  it('registers imported component declarations as external symbols', () => {
+    const projectModel = new ProjectModel();
+    projectModel.updateDocument('test://component-import.qtn', `
+import component ExternalPlayer;
+component UsesImport {
+  ExternalPlayer Player;
+}`);
+
+    const symbol = projectModel.getSymbolTable().lookup('ExternalPlayer');
+    expect(symbol?.source).toBe('import');
+    expect(symbol?.kind).toBe(SymbolKind.Class);
+    expect(symbol?.detail).toBe('import component');
+  });
+
   it('parses component inheritance and abstract singleton components', () => {
     const result = parse(`
 abstract component BaseComponent {

--- a/language-server/src/builtins.ts
+++ b/language-server/src/builtins.ts
@@ -213,4 +213,4 @@ export const FIELD_MODIFIER_KEYWORDS: string[] = [
 ];
 
 // Import sub-keywords
-export const IMPORT_SUB_KEYWORDS: string[] = ['struct', 'enum', 'singleton'];
+export const IMPORT_SUB_KEYWORDS: string[] = ['struct', 'enum', 'component', 'singleton'];

--- a/language-server/src/parser.ts
+++ b/language-server/src/parser.ts
@@ -653,6 +653,20 @@ class Parser {
       };
     }
 
+    // import component Name;
+    if (tok.type === TokenType.keyword && tok.value === 'component') {
+      this.advance();
+      const name = this.parseDottedName();
+      this.expect(TokenType.punctuation, ';');
+      return {
+        kind: 'import',
+        importKind: 'component',
+        name,
+        range: this.makeRange(startRange, this.prevRange()),
+        fileUri: this.fileUri,
+      };
+    }
+
     // import Name;  or  import Namespace.Sub.Name;
     const name = this.parseDottedName();
     this.expect(TokenType.punctuation, ';');


### PR DESCRIPTION
## Summary
- parse `import component Name;` as an external component symbol
- offer `component` in import completions

## Tests
- `npx -y -p node@20 -p npm@10 npm --prefix language-server test -- src/__tests__/user-visible-bugs.test.ts src/__tests__/completion.test.ts`
- `npx -y -p node@20 -p npm@10 npm run compile`