### PR TITLE
fix: parse local and remote event modifiers

### DIFF
--- a/language-server/src/__tests__/user-visible-bugs.test.ts
+++ b/language-server/src/__tests__/user-visible-bugs.test.ts
@@ -94,6 +94,29 @@ abstract singleton component AbstractSingleton {
     expect(singleton.modifiers).toEqual(['abstract', 'singleton']);
   });
 
+  it('parses local and remote event modifiers at top level', () => {
+    const result = parse(`
+local event LocalOnly {
+  PlayerRef Player;
+}
+
+remote event RemoteOnly {
+  PlayerRef Player;
+}`, 'test://local-remote-events.qtn');
+
+    expect(result.parseErrors).toHaveLength(0);
+
+    const localEvent = result.definitions.find((def) => def.kind === 'event' && def.name === 'LocalOnly');
+    const remoteEvent = result.definitions.find((def) => def.kind === 'event' && def.name === 'RemoteOnly');
+
+    if (localEvent?.kind !== 'event' || remoteEvent?.kind !== 'event') {
+      throw new Error('Expected local and remote event definitions');
+    }
+
+    expect(localEvent.modifiers).toEqual(['local']);
+    expect(remoteEvent.modifiers).toEqual(['remote']);
+  });
+
   it('formats pointer signal parameters using QTN suffix syntax once', () => {
     const result = parse(`
 struct Resources {}

--- a/language-server/src/parser.ts
+++ b/language-server/src/parser.ts
@@ -302,6 +302,24 @@ class Parser {
           this.skipToRecoveryPoint();
           return null;
         }
+        case 'local': {
+          const localTok = this.advance();
+          if (this.check(TokenType.keyword, 'event')) {
+            return this.parseEvent(['local'], attributes, localTok.range);
+          }
+          this.addError("Expected 'event' after 'local'", this.current().range);
+          this.skipToRecoveryPoint();
+          return null;
+        }
+        case 'remote': {
+          const remoteTok = this.advance();
+          if (this.check(TokenType.keyword, 'event')) {
+            return this.parseEvent(['remote'], attributes, remoteTok.range);
+          }
+          this.addError("Expected 'event' after 'remote'", this.current().range);
+          this.skipToRecoveryPoint();
+          return null;
+        }
         case 'signal':
           return this.parseSignal(attributes);
         case 'input':


### PR DESCRIPTION
## Summary
- accept top-level `local event` and `remote event` declarations
- preserve the modifier on parsed event definitions

## Tests
- `npx -y -p node@20 -p npm@10 npm --prefix language-server test -- src/__tests__/user-visible-bugs.test.ts`
- `npx -y -p node@20 -p npm@10 npm run compile`