### PR TITLE
feat: show signal parameters in document symbols

### DIFF
--- a/language-server/src/__tests__/symbols.test.ts
+++ b/language-server/src/__tests__/symbols.test.ts
@@ -37,6 +37,15 @@ describe('Document symbols', () => {
     );
     expect(symbols).toEqual([]);
   });
+
+  it('returns signal parameters as nested document symbols', () => {
+    const { projectModel, uri } = setupDocument('signal OnDamage(EntityRef target, FP amount);');
+    const symbols = handleDocumentSymbol({ textDocument: { uri } }, projectModel);
+
+    const signal = symbols.find((s) => s.name === 'OnDamage');
+    expect(signal?.children?.map((child) => child.name)).toEqual(['target', 'amount']);
+    expect(signal?.children?.map((child) => child.detail)).toEqual(['EntityRef', 'FP']);
+  });
 });
 
 describe('Workspace symbols', () => {

--- a/language-server/src/symbols.ts
+++ b/language-server/src/symbols.ts
@@ -24,6 +24,7 @@ import {
   DefineDefinition,
   FieldDefinition,
   EnumMemberDefinition,
+  ParameterDefinition,
   SourceRange,
 } from './ast.js';
 
@@ -60,6 +61,19 @@ function createEnumMemberSymbol(member: EnumMemberDefinition): DocumentSymbol {
     range: sourceRangeToLspRange(member.range),
     selectionRange: sourceRangeToLspRange(member.range),
     detail: member.value !== undefined ? `= ${member.value}` : undefined,
+  };
+}
+
+/**
+ * Create DocumentSymbol for a signal parameter
+ */
+function createParameterSymbol(parameter: ParameterDefinition): DocumentSymbol {
+  return {
+    name: parameter.name,
+    kind: SymbolKind.Variable,
+    range: sourceRangeToLspRange(parameter.range),
+    selectionRange: sourceRangeToLspRange(parameter.range),
+    detail: formatTypeReference(parameter.typeRef),
   };
 }
 
@@ -143,6 +157,7 @@ function createDefinitionSymbol(def: Definition): DocumentSymbol {
         range,
         selectionRange,
         detail: `(${paramTypes})`,
+        children: signalDef.parameters.map((parameter) => createParameterSymbol(parameter)),
       };
     }
 


### PR DESCRIPTION
## Summary
- expose signal parameters as nested document symbols
- include each parameter type as the document symbol detail

## Tests
- `npx -y -p node@20 -p npm@10 npm --prefix language-server test -- src/__tests__/symbols.test.ts`
- `npx -y -p node@20 -p npm@10 npm run compile`