### PR TITLE
feat: retain signal parameters in symbol table

### DIFF
--- a/language-server/src/__tests__/symbol-table.test.ts
+++ b/language-server/src/__tests__/symbol-table.test.ts
@@ -64,3 +64,24 @@ describe('SymbolTable fuzzySearch cache invalidation', () => {
     expect(currentResults).toContain('CurrentType');
   });
 });
+
+describe('SymbolTable signal parameters', () => {
+  it('should retain signal parameters as child symbols', () => {
+    const table = new SymbolTable();
+    const doc = parse(
+      `
+      signal OnDamage(EntityRef target, FP amount);
+      `,
+      'test://signals.qtn'
+    );
+
+    table.addFromDocument(doc);
+
+    const signal = table.lookup('OnDamage');
+    expect(signal?.children.map((child) => child.name)).toEqual(['target', 'amount']);
+    expect(signal?.children.map((child) => child.detail)).toEqual([
+      'target: EntityRef',
+      'amount: FP',
+    ]);
+  });
+});

--- a/language-server/src/symbol-table.ts
+++ b/language-server/src/symbol-table.ts
@@ -12,6 +12,7 @@ import {
   DefineDefinition,
   FieldDefinition,
   EnumMemberDefinition,
+  ParameterDefinition,
   NodeKind,
   SourceRange,
 } from './ast.js';
@@ -268,13 +269,14 @@ export class SymbolTable {
   // Process signal definition
   private processSignalDefinition(def: SignalDefinition, fileUri: string): void {
     const detail = buildSignalDetail(def);
+    const children = def.parameters.map((parameter) => this.createParameterSymbol(parameter, fileUri));
 
     const symbol: SymbolInfo = {
       name: def.name,
       kind: SymbolKind.Function,
       location: createLocation(fileUri, def.range),
       detail,
-      children: [],
+      children,
       source: 'user',
     };
 
@@ -360,6 +362,19 @@ export class SymbolTable {
       kind: SymbolKind.EnumMember,
       location: createLocation(fileUri, member.range),
       detail: `${member.name}${valueStr}`,
+      children: [],
+      source: 'user',
+    };
+  }
+
+  // Create signal parameter symbol
+  private createParameterSymbol(parameter: ParameterDefinition, fileUri: string): SymbolInfo {
+    const typeStr = formatTypeReference(parameter.typeRef);
+    return {
+      name: parameter.name,
+      kind: SymbolKind.Variable,
+      location: createLocation(fileUri, parameter.range),
+      detail: `${parameter.name}: ${typeStr}`,
       children: [],
       source: 'user',
     };


### PR DESCRIPTION
## Summary
- store signal parameters as child symbols on signal entries
- keep parameter detail strings consistent with field detail formatting

## Tests
- `npx -y -p node@20 -p npm@10 npm --prefix language-server test -- src/__tests__/symbol-table.test.ts`
- `npx -y -p node@20 -p npm@10 npm run compile`