### PR TITLE
feat: emit semantic tokens for event parent references

### DIFF
--- a/language-server/src/__tests__/semantic-tokens.test.ts
+++ b/language-server/src/__tests__/semantic-tokens.test.ts
@@ -216,4 +216,28 @@ component Player {
     const lines = new Set(tokens.map(t => t.line));
     expect(lines.size).toBeGreaterThanOrEqual(2);
   });
+
+  it('should emit token for user-defined event parent references', () => {
+    const source = `
+event BaseEvent {
+  FP Time;
+}
+event ChildEvent : BaseEvent {
+  FP Amount;
+}`;
+    const result = getTokens(source);
+    expect(result).not.toBeNull();
+
+    const tokens = decodeTokens(result!.data);
+    expect(tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          line: 4,
+          char: 'event ChildEvent : '.length,
+          length: 'BaseEvent'.length,
+          tokenType: tokenTypes.indexOf('event'),
+        }),
+      ]),
+    );
+  });
 });

--- a/language-server/src/ast.ts
+++ b/language-server/src/ast.ts
@@ -87,6 +87,7 @@ export interface EventDefinition extends QtnAstNode {
   name: string;
   modifiers: string[];  // synced, abstract, client, server
   parentName?: string;  // inheritance: event Foo : Bar
+  parentNameRange?: SourceRange;
   fields: FieldDefinition[];
 }
 

--- a/language-server/src/parser.ts
+++ b/language-server/src/parser.ts
@@ -489,8 +489,11 @@ class Parser {
     const name = this.expectIdentifierOrKeyword('event name');
 
     let parentName: string | undefined;
+    let parentNameRange: SourceRange | undefined;
     if (this.match(TokenType.punctuation, ':')) {
-      parentName = this.expectIdentifierOrKeyword('parent event name').value;
+      const parentTok = this.expectIdentifierOrKeyword('parent event name');
+      parentName = parentTok.value;
+      parentNameRange = parentTok.range;
     }
 
     const fields = this.parseFieldBlock();
@@ -501,6 +504,7 @@ class Parser {
       name: name.value,
       modifiers: [...modifiers],
       parentName,
+      parentNameRange,
       fields,
       range: this.makeRange(startRange, endRange),
       fileUri: this.fileUri,

--- a/language-server/src/semantic-tokens.ts
+++ b/language-server/src/semantic-tokens.ts
@@ -157,14 +157,16 @@ export function handleSemanticTokensFull(
     // Handle event parent type reference (inheritance)
     if (def.kind === 'event') {
       const eventDef = def as EventDefinition;
-      if (eventDef.parentName) {
+      if (eventDef.parentName && eventDef.parentNameRange) {
         const parentSymbol = symbolTable.lookup(eventDef.parentName);
-        if (parentSymbol) {
-          // Find parent name range: it's after `:` in the event declaration
-          // We need to locate it in the source. Since we don't have a dedicated
-          // parentNameRange in the AST, we compute it from the event range.
-          // For now, skip — parentName range is not tracked in the AST.
-          // This can be added in a future enhancement.
+        if (parentSymbol && parentSymbol.source !== 'builtin') {
+          tokens.push({
+            line: eventDef.parentNameRange.start.line,
+            char: eventDef.parentNameRange.start.character,
+            length: eventDef.parentName.length,
+            tokenType: symbolKindToTokenType(parentSymbol.kind),
+            tokenModifiers: 0,
+          });
         }
       }
     }


### PR DESCRIPTION
## Summary
- track `event Foo : Parent` parent-name ranges in the AST
- emit semantic tokens for user/import event parent references

## Tests
- `npx -y -p node@20 -p npm@10 npm --prefix language-server test -- src/__tests__/semantic-tokens.test.ts`
- `npx -y -p node@20 -p npm@10 npm run compile`