### PR TITLE
fix: show pragma keys in workspace symbols

### DIFF
--- a/language-server/src/__tests__/symbols.test.ts
+++ b/language-server/src/__tests__/symbols.test.ts
@@ -52,4 +52,23 @@ describe('Workspace symbols', () => {
     // FP is a builtin — must not appear as a workspace symbol.
     expect(results.some((s) => s.name === 'FP')).toBe(false);
   });
+
+  it('uses descriptive names for directives in empty workspace search', () => {
+    const { projectModel } = setupDocument(`#pragma max_players 8
+#define MAX_PLAYERS 8
+using Game.Core;
+input {
+  button Fire;
+}`);
+    const results = handleWorkspaceSymbol({ query: '' }, projectModel);
+    const names = results.map((symbol) => symbol.name);
+
+    expect(names).toEqual(expect.arrayContaining([
+      '#pragma max_players',
+      'MAX_PLAYERS',
+      'Game.Core',
+      'input',
+    ]));
+    expect(names).not.toContain('pragma');
+  });
 });

--- a/language-server/src/symbols.ts
+++ b/language-server/src/symbols.ts
@@ -222,6 +222,18 @@ function createDefinitionSymbol(def: Definition): DocumentSymbol {
   }
 }
 
+function workspaceSymbolName(def: Definition): string {
+  switch (def.kind) {
+    case 'pragma':
+      return `#pragma ${(def as PragmaDefinition).key}`;
+    case 'input':
+    case 'global':
+      return def.kind;
+    default:
+      return def.name ?? def.kind;
+  }
+}
+
 /**
  * Handle textDocument/documentSymbol request
  * Provides hierarchical symbol outline for the current document
@@ -264,7 +276,7 @@ export function handleWorkspaceSymbol(
         // Skip builtin symbols - we only want user-defined symbols
         // (builtins don't have definitions in documents anyway)
         const symbol: SymbolInformation = {
-          name: def.name || def.kind,
+          name: workspaceSymbolName(def),
           kind: nodeKindToSymbolKind(def.kind),
           location: {
             uri: doc.uri,


### PR DESCRIPTION
## Summary
- use `#pragma <key>` as the workspace symbol name for pragma definitions
- keep input/global fallback names explicit for empty workspace searches

## Tests
- `npx -y -p node@20 -p npm@10 npm --prefix language-server test -- src/__tests__/symbols.test.ts`
- `npx -y -p node@20 -p npm@10 npm run compile`