### PR TITLE
fix: skip worktree directories during indexing

### DIFF
--- a/language-server/src/__tests__/workspace-index.test.ts
+++ b/language-server/src/__tests__/workspace-index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { shouldSkipDirectory } from '../workspace-index.js';
+
+describe('workspace indexing helpers', () => {
+  it('skips generated and auxiliary directories', () => {
+    expect(shouldSkipDirectory('.git')).toBe(true);
+    expect(shouldSkipDirectory('node_modules')).toBe(true);
+    expect(shouldSkipDirectory('dist')).toBe(true);
+    expect(shouldSkipDirectory('out')).toBe(true);
+    expect(shouldSkipDirectory('build')).toBe(true);
+    expect(shouldSkipDirectory('.worktrees')).toBe(true);
+  });
+
+  it('does not skip ordinary source directories', () => {
+    expect(shouldSkipDirectory('src')).toBe(false);
+    expect(shouldSkipDirectory('shared')).toBe(false);
+    expect(shouldSkipDirectory('Gameplay')).toBe(false);
+  });
+});

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -21,6 +21,7 @@ import { handleHover } from './hover.js';
 import { handleDocumentSymbol, handleWorkspaceSymbol } from './symbols.js';
 import { handleSemanticTokensFull, tokenTypes, tokenModifiers } from './semantic-tokens.js';
 import { setLocale } from './locale.js';
+import { shouldSkipDirectory } from './workspace-index.js';
 
 // Create LSP connection using Node IPC
 const connection = createConnection(ProposedFeatures.all);
@@ -207,14 +208,6 @@ async function findQtnFiles(root: string): Promise<string[]> {
 
   await visit(root);
   return files;
-}
-
-function shouldSkipDirectory(name: string): boolean {
-  return name === '.git' ||
-    name === 'node_modules' ||
-    name === 'dist' ||
-    name === 'out' ||
-    name === 'build';
 }
 
 function uriToFilePath(uri: string): string | null {

--- a/language-server/src/workspace-index.ts
+++ b/language-server/src/workspace-index.ts
@@ -1,0 +1,12 @@
+const SKIPPED_DIRECTORIES = new Set([
+  '.git',
+  '.worktrees',
+  'node_modules',
+  'dist',
+  'out',
+  'build',
+]);
+
+export function shouldSkipDirectory(name: string): boolean {
+  return SKIPPED_DIRECTORIES.has(name);
+}


### PR DESCRIPTION
## Summary
- extract workspace indexing skip logic into a tested helper
- skip `.worktrees` so local PR worktrees do not get indexed as project files

## Tests
- `npx -y -p node@20 -p npm@10 npm --prefix language-server test -- src/__tests__/workspace-index.test.ts`
- `npx -y -p node@20 -p npm@10 npm run compile`