### PR TITLE
fix: update VSCode extension repository URL

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shlifedev/QtnLSP"
+    "url": "https://github.com/shlifedev/photon-quantum-qtn-lsp"
   },
   "contributes": {
     "languages": [


### PR DESCRIPTION
## Summary
- point the VSCode extension manifest repository URL at the actual GitHub repository

## Tests
- `node -e "const pkg=require('./vscode-extension/package.json'); if (pkg.repository.url !== 'https://github.com/shlifedev/photon-quantum-qtn-lsp') process.exit(1)"`
- `npx -y -p node@20 -p npm@10 npm --prefix vscode-extension run build`